### PR TITLE
Treat PATCH as a HTTP verb

### DIFF
--- a/proto/proto.go
+++ b/proto/proto.go
@@ -443,7 +443,7 @@ func Status(payload []byte) []byte {
 }
 
 var httpMethods []string = []string{
-	"GET ", "OPTI", "HEAD", "POST", "PUT ", "DELE", "TRAC", "CONN" /* custom methods */, "BAN", "PURG",
+	"GET ", "OPTI", "HEAD", "POST", "PUT ", "DELE", "TRAC", "CONN", "PATC" /* custom methods */, "BAN", "PURG",
 }
 
 func IsHTTPPayload(payload []byte) bool {


### PR DESCRIPTION
I'm not sure whether this was omitted intentionally for some reason, but it was pretty weird to me to see `PATCH` requests in a dump when I had specified `--http-allow-method GET`.
