### PR TITLE
Fix crashes in ParseHeaders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ gor
 *.pcap
 
 .DS_Store
+
+corpus
+crashers
+suppressions

--- a/proto/fuzz.go
+++ b/proto/fuzz.go
@@ -1,0 +1,12 @@
+// +build gofuzz
+
+package proto
+
+func Fuzz(data []byte) int {
+
+    ParseHeaders([][]byte{data}, func(header []byte, value []byte) bool {
+      return true
+    })
+
+    return 1
+}

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -181,11 +181,10 @@ func HeadersEqual(h1 []byte, h2 []byte) bool {
 
 // Parsing headers from multiple payloads
 func ParseHeaders(payloads [][]byte, cb func(header []byte, value []byte) bool) {
-
-	hS := [2]int{0, 0}
-	hE := [2]int{-1, -1}
-	vS := [2]int{-1, -1}
-	vE := [2]int{-1, -1}
+	hS := [2]int{0, 0} // header start
+	hE := [2]int{-1, -1} // header end
+	vS := [2]int{-1, -1} // value start
+	vE := [2]int{-1, -1} // value end
 
 	i := 0
 	pIdx := 0
@@ -260,11 +259,13 @@ func ParseHeaders(payloads [][]byte, cb func(header []byte, value []byte) bool) 
 				hE = [2]int{pIdx, i}
 				newLineBreak = false
 			}
+			lineBreaks = 0
 		default:
 			lineBreaks = 0
 
 			if hS[1] == -1 {
 				hS = [2]int{pIdx, i}
+				hE = [2]int{-1, -1}
 			} else {
 				if hE[1] == -1 {
 					break

--- a/proto/proto_test.go
+++ b/proto/proto_test.go
@@ -145,6 +145,19 @@ func TestParseHeaders(t *testing.T) {
 	}
 }
 
+// See https://github.com/dvyukov/go-fuzz and fuzz.go
+func TestFuzzCrashers(t *testing.T) {
+	var crashers = []string{
+		"\n:00\n",
+	}
+
+	for _, f := range crashers {
+		ParseHeaders([][]byte{[]byte(f)}, func(header []byte, value []byte) bool {
+	      return true
+	    })
+	}
+}
+
 func TestParseHeadersWithComplexUserAgent(t *testing.T) {
 	// User-Agent could contain inside ':'
 	// Parser should wait for \r\n


### PR DESCRIPTION
This PR should fix panics inside HTTP protocol code #408, and this case is quite interesting. 

I could not replicate bug manually and decided to try a fuzzing.

> Fuzzing or fuzz testing is a software testing technique, often automated or semi-automated, that involves providing invalid, unexpected, or random data to the inputs of a computer program.
https://en.wikipedia.org/wiki/Fuzzing

The basic idea that it is that fuzzer is massively scaled random generator, which tries to run your function with all possible combinations. And Golang have a really nice one: https://github.com/dvyukov/go-fuzz

It's quite easy to use it, for testing proto library command was:
```
// Creates zip file with binary
go-fuzz-build github.com/buger/gor/proto

// Runs the fuzzer and in current directory creates 3 directories: corpus, crashers, suppressions
go-fuzz -workdir ./ -bin ./proto-fuzz.zip
```

After it finished, we need to look at `crashers` directory, which will contain file with panic trace, and actual input which caused the issue. 

Take a look PR itself to understand what it does.