### PR TITLE
Allow spaces inside filters

### DIFF
--- a/http_modifier_settings.go
+++ b/http_modifier_settings.go
@@ -43,7 +43,8 @@ func (h *HTTPHeaderFilters) Set(value string) error {
 	if len(valArr) < 2 {
 		return errors.New("need both header and value, colon-delimited (ex. user_id:^169$).")
 	}
-	r, err := regexp.Compile(valArr[1])
+	val := strings.TrimSpace(valArr[1])
+	r, err := regexp.Compile(val)
 	if err != nil {
 		return err
 	}
@@ -75,14 +76,16 @@ func (h *HTTPHashFilters) Set(value string) error {
 
 	f := hashFilter{name: []byte(valArr[0])}
 
-	if strings.Contains(valArr[1], "%") {
-		p, _ := strconv.ParseInt(valArr[1][:len(valArr[1])-1], 0, 0)
+	val := strings.TrimSpace(valArr[1])
+
+	if strings.Contains(val, "%") {
+		p, _ := strconv.ParseInt(val[:len(val)-1], 0, 0)
 		f.percent = uint32(p)
-	} else if strings.Contains(valArr[1], "/") {
+	} else if strings.Contains(val, "/") {
 		// DEPRECATED format
 		var num, den uint64
 
-		fracArr := strings.Split(valArr[1], "/")
+		fracArr := strings.Split(val, "/")
 		num, _ = strconv.ParseUint(fracArr[0], 10, 64)
 		den, _ = strconv.ParseUint(fracArr[1], 10, 64)
 

--- a/http_modifier_test.go
+++ b/http_modifier_test.go
@@ -64,6 +64,18 @@ func TestHTTPModifierHeaderNegativeFilters(t *testing.T) {
 	if len(modifier.Rewrite(payload)) != 0 {
 		t.Error("Request should not pass filters")
 	}
+
+	filters = HTTPHeaderFilters{}
+	// Setting filter that not match our header
+	filters.Set("Host: www*")
+
+	modifier = NewHTTPModifier(&HTTPModifierConfig{
+		headerNegativeFilters: filters,
+	})
+
+	if len(modifier.Rewrite(payload)) != 0 {
+		t.Error("Request should not pass filters")
+	}
 }
 
 func TestHTTPModifierURLRewrite(t *testing.T) {


### PR DESCRIPTION
Right now if you put trailing space when filtering or rewriting headers, it will not recognize filter.

Example `--http-disallow-header 'Host: www.vertaa.fi'`: space between 'Host:' and host value cause the issue.

Very confusing to new users, should fix #369

With this fix it now clean up trailing spaces.