### PR TITLE
Allow to use payload type for file names

### DIFF
--- a/output_file.go
+++ b/output_file.go
@@ -24,7 +24,8 @@ var dateFileNameFuncs = map[string]func(*FileOutput) string{
 	"%M":  func(o *FileOutput) string { return time.Now().Format("04") },
 	"%S":  func(o *FileOutput) string { return time.Now().Format("05") },
 	"%NS": func(o *FileOutput) string { return fmt.Sprint(time.Now().Nanosecond()) },
-	"%r":  func(o *FileOutput) string { return o.currentID },
+	"%r":  func(o *FileOutput) string { return string(o.currentID) },
+	"%t":  func(o *FileOutput) string { return string(o.payloadType) },
 }
 
 type FileOutputConfig struct {
@@ -44,7 +45,8 @@ type FileOutput struct {
 	chunkSize      int
 	writer         io.Writer
 	requestPerFile bool
-	currentID      string
+	currentID      []byte
+	payloadType    []byte
 	closed         bool
 
 	config *FileOutputConfig
@@ -182,7 +184,9 @@ func (o *FileOutput) updateName() {
 
 func (o *FileOutput) Write(data []byte) (n int, err error) {
 	if o.requestPerFile {
-		o.currentID = string(payloadMeta(data)[1])
+		meta := payloadMeta(data)
+		o.currentID = meta[1]
+		o.payloadType = meta[0]
 		o.updateName()
 	}
 

--- a/output_file_test.go
+++ b/output_file_test.go
@@ -65,9 +65,10 @@ func TestFileOutputWithNameCleaning(t *testing.T) {
 }
 
 func TestFileOutputPathTemplate(t *testing.T) {
-	output := &FileOutput{pathTemplate: "/tmp/log-%Y-%m-%d-%S", config: &FileOutputConfig{flushInterval: time.Minute, append: true}}
+	output := &FileOutput{pathTemplate: "/tmp/log-%Y-%m-%d-%S-%t", config: &FileOutputConfig{flushInterval: time.Minute, append: true}}
 	now := time.Now()
-	expectedPath := fmt.Sprintf("/tmp/log-%s-%s-%s-%s", now.Format("2006"), now.Format("01"), now.Format("02"), now.Format("05"))
+	output.payloadType = []byte("3")
+	expectedPath := fmt.Sprintf("/tmp/log-%s-%s-%s-%s-3", now.Format("2006"), now.Format("01"), now.Format("02"), now.Format("05"))
 	path := output.filename()
 
 	if expectedPath != path {


### PR DESCRIPTION
Added new %t file template variable, so you can log requests, responses, and replayed responses into separate files. 

Example: “/tmp/log-%Y-%m-%d-%S.%t”