### PR TITLE
Prettify HTTP

### DIFF
--- a/emitter.go
+++ b/emitter.go
@@ -100,6 +100,10 @@ func CopyMulty(src io.Reader, writers ...io.Writer) (err error) {
 				}
 			}
 
+			if Settings.prettifyHTTP {
+				payload = prettifyHTTP(payload)
+			}
+
 			if Settings.splitOutput {
 				// Simple round robin
 				writers[wIndex].Write(payload)

--- a/http_prettifier.go
+++ b/http_prettifier.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+    "github.com/buger/gor/proto"
+    "bytes"
+    "compress/gzip"
+    "strconv"
+    "io/ioutil"
+    "net/http/httputil"
+)
+
+func prettifyHTTP(p []byte) []byte {
+    headSize := bytes.IndexByte(p, '\n') + 1
+    head := p[:headSize]
+    body := p[headSize:]
+
+    headersPos := proto.MIMEHeadersEndPos(body)
+    headers := body[:headersPos]
+    content := body[headersPos:]
+
+    var tEnc, cEnc []byte
+    proto.ParseHeaders([][]byte{headers}, func(header, value []byte) bool {
+        if proto.HeadersEqual(header, []byte("Transfer-Encoding")) {
+            tEnc = value
+        }
+
+        if proto.HeadersEqual(header, []byte("Content-Encoding")) {
+            cEnc = value
+        }
+
+        return true
+    })
+
+    if len(tEnc) == 0 && len(cEnc) == 0 {
+        return p
+    }
+
+    if bytes.Equal(tEnc, []byte("chunked")) {
+        buf := bytes.NewBuffer(content)
+        r := httputil.NewChunkedReader(buf)
+        content, _ = ioutil.ReadAll(r)
+
+        headers = proto.DeleteHeader(headers, []byte("Transfer-Encoding"))
+
+        newLen := strconv.Itoa(len(content))
+        headers = proto.SetHeader(headers, []byte("Content-Length"), []byte(newLen))
+    }
+
+    if bytes.Equal(cEnc, []byte("gzip")) {
+        buf := bytes.NewBuffer(content)
+        g, err := gzip.NewReader(buf)
+
+        if err != nil {
+            Debug("[Prettifier] GZIP encoding error:", err)
+        }
+
+        content, _ = ioutil.ReadAll(g)
+
+        headers = proto.DeleteHeader(headers, []byte("Content-Encoding"))
+
+        newLen := strconv.Itoa(len(content))
+        headers = proto.SetHeader(headers, []byte("Content-Length"), []byte(newLen))
+    }
+
+    newPayload := append(append(head, headers...), content...)
+
+    return newPayload
+}

--- a/http_prettifier_test.go
+++ b/http_prettifier_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+    "compress/gzip"
+    "testing"
+    "strconv"
+    "bytes"
+)
+
+func TestHTTPPrettifierGzip(t *testing.T) {
+    b := bytes.NewBufferString("")
+    w := gzip.NewWriter(b)
+    w.Write([]byte("test"))
+    w.Close()
+
+    size := strconv.Itoa(len(b.Bytes()))
+
+    payload := []byte("2 1 1\nHTTP/1.1 200 OK\r\nContent-Length: " + size + "\r\nContent-Encoding: gzip\r\n\r\n")
+    payload = append(payload, b.Bytes()...)
+
+    newPayload := prettifyHTTP(payload)
+
+    if string(newPayload) != "2 1 1\nHTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\ntest" {
+        t.Error("Payload not match:", string(newPayload))
+    }
+}
+
+func TestHTTPPrettifierChunked(t *testing.T) {
+    payload := []byte("POST / HTTP/1.1\r\nHost: www.w3.org\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n")
+
+    newPayload := prettifyHTTP(payload)
+
+    if string(newPayload) != "POST / HTTP/1.1\r\nHost: www.w3.org\r\nContent-Length: 23\r\n\r\nWikipedia in\r\n\r\nchunks." {
+        t.Error("Payload not match:", string(newPayload))
+    }
+}

--- a/limiter.go
+++ b/limiter.go
@@ -82,7 +82,11 @@ func (l *Limiter) Write(data []byte) (n int, err error) {
 }
 
 func (l *Limiter) Read(data []byte) (n int, err error) {
-	n, err = l.plugin.(io.Reader).Read(data)
+	if r, ok := l.plugin.(io.Reader); ok {
+		n, err = r.Read(data)
+	} else {
+		return 0, nil
+	}
 
 	if l.isLimited() {
 		return 0, nil

--- a/output_file.go
+++ b/output_file.go
@@ -24,7 +24,8 @@ var dateFileNameFuncs = map[string]func(*FileOutput) string{
 	"%M":  func(o *FileOutput) string { return time.Now().Format("04") },
 	"%S":  func(o *FileOutput) string { return time.Now().Format("05") },
 	"%NS": func(o *FileOutput) string { return fmt.Sprint(time.Now().Nanosecond()) },
-	"%r":  func(o *FileOutput) string { return o.currentID },
+	"%r":  func(o *FileOutput) string { return string(o.currentID) },
+	"%t":  func(o *FileOutput) string { return string(o.payloadType) },
 }
 
 type FileOutputConfig struct {
@@ -44,7 +45,8 @@ type FileOutput struct {
 	chunkSize      int
 	writer         io.Writer
 	requestPerFile bool
-	currentID      string
+	currentID      []byte
+	payloadType    []byte
 	closed         bool
 
 	config *FileOutputConfig
@@ -182,7 +184,9 @@ func (o *FileOutput) updateName() {
 
 func (o *FileOutput) Write(data []byte) (n int, err error) {
 	if o.requestPerFile {
-		o.currentID = string(payloadMeta(data)[1])
+		meta := payloadMeta(data)
+		o.currentID = meta[1]
+		o.payloadType = meta[0]
 		o.updateName()
 	}
 

--- a/output_file_test.go
+++ b/output_file_test.go
@@ -65,9 +65,10 @@ func TestFileOutputWithNameCleaning(t *testing.T) {
 }
 
 func TestFileOutputPathTemplate(t *testing.T) {
-	output := &FileOutput{pathTemplate: "/tmp/log-%Y-%m-%d-%S", config: &FileOutputConfig{flushInterval: time.Minute, append: true}}
+	output := &FileOutput{pathTemplate: "/tmp/log-%Y-%m-%d-%S-%t", config: &FileOutputConfig{flushInterval: time.Minute, append: true}}
 	now := time.Now()
-	expectedPath := fmt.Sprintf("/tmp/log-%s-%s-%s-%s", now.Format("2006"), now.Format("01"), now.Format("02"), now.Format("05"))
+	output.payloadType = []byte("3")
+	expectedPath := fmt.Sprintf("/tmp/log-%s-%s-%s-%s-3", now.Format("2006"), now.Format("01"), now.Format("02"), now.Format("05"))
 	path := output.filename()
 
 	if expectedPath != path {

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -32,7 +32,7 @@ var HeaderDelim = []byte(": ")
 
 // MIMEHeadersEndPos finds end of the Headers section, which should end with empty line.
 func MIMEHeadersEndPos(payload []byte) int {
-	return bytes.Index(payload, EmptyLine)
+	return bytes.Index(payload, EmptyLine) + 4
 }
 
 // MIMEHeadersStartPos finds start of Headers section
@@ -337,7 +337,7 @@ func DeleteHeader(payload, name []byte) []byte {
 // Body returns request/response body
 func Body(payload []byte) []byte {
 	// 4 -> len(EMPTY_LINE)
-	return payload[MIMEHeadersEndPos(payload)+4:]
+	return payload[MIMEHeadersEndPos(payload):]
 }
 
 // Path takes payload and retuns request path: Split(firstLine, ' ')[1]

--- a/settings.go
+++ b/settings.go
@@ -56,6 +56,8 @@ type AppSettings struct {
 	inputHTTP  MultiOption
 	outputHTTP MultiOption
 
+	prettifyHTTP bool
+
 	outputHTTPConfig HTTPOutputConfig
 	modifierConfig   HTTPModifierConfig
 
@@ -104,6 +106,8 @@ func init() {
 	Settings.outputFileConfig.sizeLimit.Set("32mb")
 	flag.Var(&Settings.outputFileConfig.sizeLimit, "output-file-size-limit", "Size of each chunk. Default: 32mb")
 	flag.IntVar(&Settings.outputFileConfig.queueLimit, "output-file-queue-limit", 256, "The length of the chunk queue. Default: 256")
+
+	flag.BoolVar(&Settings.prettifyHTTP, "prettify-http", false, "If enabled, will automatically decode requests and responses with: Content-Encodning: gzip and Transfer-Encoding: chunked. Useful for debugging, in conjuction with --output-stdout")
 
 	flag.Var(&Settings.inputRAW, "input-raw", "Capture traffic from given port (use RAW sockets and require *sudo* access):\n\t# Capture traffic from 8080 port\n\tgor --input-raw :8080 --output-http staging.com")
 


### PR DESCRIPTION
Using —prettify-http option, you can automatically decode Gzip encoded responses, and de-construct chunked bodies.