### PR TITLE
Fix kafka issue

### DIFF
--- a/input_kafka.go
+++ b/input_kafka.go
@@ -22,7 +22,7 @@ func NewKafkaInput(address string, config *KafkaConfig) *KafkaInput {
 
 	var con sarama.Consumer
 
-	if config.consumer.(*mocks.Consumer) != nil {
+	if mock, ok := config.consumer.(*mocks.Consumer); ok && mock != nil {
 		con = config.consumer
 	} else {
 		var err error

--- a/output_kafka.go
+++ b/output_kafka.go
@@ -26,7 +26,7 @@ func NewKafkaOutput(address string, config *KafkaConfig) io.Writer {
 
 	var producer sarama.AsyncProducer
 
-	if config.producer.(*mocks.AsyncProducer) != nil {
+	if mock, ok := config.producer.(*mocks.AsyncProducer); ok && mock != nil {
 		producer = config.producer
 	} else {
 		c.Producer.RequiredAcks = sarama.WaitForLocal


### PR DESCRIPTION
Hi,

There is a bug with your new Kafka implementation that causes a panic.

```
# gor -input-raw :80 -output-kafka-host 'some-ip:9092' -output-kafka-topic data
panic: interface conversion: sarama.AsyncProducer is nil, not *mocks.AsyncProducer
goroutine 1 [running]:
panic(0xa701a0, 0xc820052680)
    /usr/lib/go/src/runtime/panic.go:464 +0x3e6
main.NewKafkaOutput(0x0, 0x0, 0x10f7388, 0x0, 0x0)
    /root/gocode/src/github.com/buger/gor/output_kafka.go:29 +0x43c
reflect.Value.call(0xa0e220, 0xc79348, 0x13, 0xb3f530, 0x4, 0xc82119c090, 0x2, 0x2, 0x0, 0x0, ...)
    /usr/lib/go/src/reflect/value.go:435 +0x120d
reflect.Value.Call(0xa0e220, 0xc79348, 0x13, 0xc82119c090, 0x2, 0x2, 0x0, 0x0, 0x0)
    /usr/lib/go/src/reflect/value.go:303 +0xb1
main.registerPlugin(0xa0e220, 0xc79348, 0xc821157c40, 0x2, 0x2)
    /root/gocode/src/github.com/buger/gor/plugins.go:57 +0x396
main.InitPlugins()
    /root/gocode/src/github.com/buger/gor/plugins.go:147 +0x1517
main.main()
    /root/gocode/src/github.com/buger/gor/gor.go:60 +0xde0
```

This is the fix I came up with.

Thanks.