### PR TITLE
fix: add basic auth support in elastic URI

### DIFF
--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -62,13 +62,11 @@ type ESRequestResponse struct {
 func parseURI(URI string) (err error, index string) {
 
 	parsedUrl, parseErr := url.Parse(URI)
-	log.Println("Parsed URL", parsedUrl)
 
 	if parseErr != nil {
 		err = new(ESUriErorr)
 	}
 
-	log.Println("Parsed Host", parsedUrl.Host)
 	//	check URL validity by extracting host and undex values.
 	host := parsedUrl.Host
 	urlPathParts := strings.Split(parsedUrl.Path, "/")
@@ -78,8 +76,6 @@ func parseURI(URI string) (err error, index string) {
 	if (host == "" ||  index == "") {
 		err = new(ESUriErorr)
 	}
-
-	//log.Println("Parsed index", index)
 
 	return
 }

--- a/elasticsearch_test.go
+++ b/elasticsearch_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"testing"
+)
+
+// Argument host:port/index_name
+// i.e : localhost:9200/gor
+func TestElasticConnectionBuildFailWithoutScheme(t *testing.T) {
+	uri := "localhost:9200/gor"
+	expectedErr := new(ESUriErorr)
+
+  err, _, _, _ := parseURI(uri)
+
+	if expectedErr != err {
+		t.Errorf("Expected err %s but got %s", expectedErr, err)
+	}
+}
+
+// Argument scheme://host/index_name
+// i.e : http://localhost/gor
+func TestElasticConnectionBuildFailWithoutPort(t *testing.T) {
+	uri := "http://localhost/gor"
+	expectedErr := new(ESUriErorr)
+
+  err, _, _, _ := parseURI(uri)
+
+	if expectedErr != err {
+		t.Errorf("Expected err %s but got %s", expectedErr, err)
+	}
+}
+
+// Argument scheme://host:port
+// i.e : http://localhost:9200
+func TestElasticConnectionBuildFailWithoutIndex(t *testing.T) {
+	uri := "http://localhost:9200"
+	expectedErr := new(ESUriErorr)
+
+  err, _, _, _ := parseURI(uri)
+
+	if expectedErr != err {
+		t.Errorf("Expected err %s but got %s", expectedErr, err)
+	}
+}
+
+// Argument host:port/index_name
+// i.e : localhost.local:9200/gor
+func TestElasticLocalConnectionBuild(t *testing.T) {
+	uri := "http://localhost:9200/gor"
+	expectedHost := "http://localhost"
+	expectedApiPort := "9200"
+	expectedIndex := "gor"
+
+	err, host, apiPort, index := parseURI(uri)
+
+	if nil != err {
+		t.Fatalf("Expected err %s but got %s", nil, err)
+	}
+	if expectedHost != host {
+		t.Fatalf("Expected host %s but got %s", expectedHost, host)
+	}
+	if expectedApiPort != apiPort {
+		t.Fatalf("Expected port %s but got %s", expectedApiPort, apiPort)
+	}
+	if expectedIndex != index {
+		t.Fatalf("Expected index %s but got %s", expectedIndex, index)
+	}
+}
+
+// Argument host:port/index_name
+// i.e : http://localhost.local:9200/gor or https://localhost.local:9200/gor
+func TestElasticSimpleLocalWithSchemeConnectionBuild(t *testing.T) {
+	uri := "http://localhost.local:9200/gor"
+	expectedHost := "http://localhost.local"
+	expectedApiPort := "9200"
+	expectedIndex := "gor"
+
+	err, host, apiPort, index := parseURI(uri)
+
+	if nil != err {
+		t.Fatalf("Expected err %s but got %s", nil, err)
+	}
+	if expectedHost != host {
+		t.Fatalf("Expected host %s but got %s", expectedHost, host)
+	}
+	if expectedApiPort != apiPort {
+		t.Fatalf("Expected port %s but got %s", expectedApiPort, apiPort)
+	}
+	if expectedIndex != index {
+		t.Fatalf("Expected index %s but got %s", expectedIndex, index)
+	}
+}
+
+// Argument host:port/index_name
+// i.e : http://localhost.local:9200/gor or https://localhost.local:9200/gor
+func TestElasticSimpleLocalWithHTTPSConnectionBuild(t *testing.T) {
+	uri := "https://localhost.local:9200/gor"
+	expectedHost := "https://localhost.local"
+	expectedApiPort := "9200"
+	expectedIndex := "gor"
+
+	err, host, apiPort, index := parseURI(uri)
+
+	if nil != err {
+		t.Fatalf("Expected err %s but got %s", nil, err)
+	}
+	if expectedHost != host {
+		t.Fatalf("Expected host %s but got %s", expectedHost, host)
+	}
+	if expectedApiPort != apiPort {
+		t.Fatalf("Expected port %s but got %s", expectedApiPort, apiPort)
+	}
+	if expectedIndex != index {
+		t.Fatalf("Expected index %s but got %s", expectedIndex, index)
+	}
+}
+
+// Argument host:port/index_name
+// i.e : localhost.local:9200/pathtoElastic/gor
+func TestElasticLongPathConnectionBuild(t *testing.T) {
+	uri := "http://localhost.local:9200/pathtoElastic/gor"
+	expectedHost := "http://localhost.local"
+	expectedApiPort := "9200"
+	expectedIndex := "gor"
+
+	err, host, apiPort, index := parseURI(uri)
+
+	if nil != err {
+		t.Fatalf("Expected err %s but got %s", nil, err)
+	}
+	if expectedHost != host {
+		t.Fatalf("Expected host %s but got %s", expectedHost, host)
+	}
+	if expectedApiPort != apiPort {
+		t.Fatalf("Expected port %s but got %s", expectedApiPort, apiPort)
+	}
+	if expectedIndex != index {
+		t.Fatalf("Expected index %s but got %s", expectedIndex, index)
+	}
+}
+
+// Argument host:port/index_name
+// i.e : http://user:password@localhost.local:9200/gor
+func TestElasticBasicAuthConnectionBuild(t *testing.T) {
+	uri := "http://user:password@localhost.local:9200/gor"
+	expectedHost := "http://localhost.local"
+	expectedApiPort := "9200"
+	expectedIndex := "gor"
+
+	err, host, apiPort, index := parseURI(uri)
+
+	if nil != err {
+		t.Fatalf("Expected err %s but got %s", nil, err)
+	}
+	if expectedHost != host {
+		t.Fatalf("Expected host %s but got %s", expectedHost, host)
+	}
+	if expectedApiPort != apiPort {
+		t.Fatalf("Expected port %s but got %s", expectedApiPort, apiPort)
+	}
+	if expectedIndex != index {
+		t.Fatalf("Expected index %s but got %s", expectedIndex, index)
+	}
+}

--- a/elasticsearch_test.go
+++ b/elasticsearch_test.go
@@ -4,161 +4,137 @@ import (
 	"testing"
 )
 
+const expectedIndex = "gor"
+
+func assertExpectedGorIndex (index string, t *testing.T) {
+	if expectedIndex != index {
+		t.Fatalf("Expected index %s but got %s", expectedIndex, index)
+	}
+}
+
+func assertExpectedIndex (expectedIndex string, index string, t *testing.T) {
+	if expectedIndex != index {
+		t.Fatalf("Expected index %s but got %s", expectedIndex, index)
+	}
+}
+
+func assertExpectedError (returnedError error, t *testing.T) {
+	expectedError := new(ESUriErorr)
+
+	if expectedError != returnedError {
+		t.Errorf("Expected err %s but got %s", expectedError, returnedError)
+	}
+}
+
+func assertNoError (returnedError error, t *testing.T) {
+	if nil != returnedError {
+		t.Errorf("Expected err %s but got %s", nil, returnedError)
+	}
+}
+
 // Argument host:port/index_name
 // i.e : localhost:9200/gor
+// Fail because scheme is mandatory
 func TestElasticConnectionBuildFailWithoutScheme(t *testing.T) {
-	uri := "localhost:9200/gor"
-	expectedErr := new(ESUriErorr)
+	uri := "localhost:9200/" + expectedIndex
 
-  err, _, _, _ := parseURI(uri)
+  err, _ := parseURI(uri)
+	assertExpectedError(err, t)
+}
 
-	if expectedErr != err {
-		t.Errorf("Expected err %s but got %s", expectedErr, err)
-	}
+// Argument scheme://host:port
+// i.e : http://localhost:9200
+// Fail : explicit index is required
+func TestElasticConnectionBuildFailWithoutIndex(t *testing.T) {
+	uri := "http://localhost:9200"
+
+  err, index := parseURI(uri)
+
+	assertExpectedIndex("", index, t)
+
+	assertExpectedError(err, t)
 }
 
 // Argument scheme://host/index_name
 // i.e : http://localhost/gor
 func TestElasticConnectionBuildFailWithoutPort(t *testing.T) {
-	uri := "http://localhost/gor"
-	expectedErr := new(ESUriErorr)
+	uri := "http://localhost/" + expectedIndex
 
-  err, _, _, _ := parseURI(uri)
+	err, index := parseURI(uri)
 
-	if expectedErr != err {
-		t.Errorf("Expected err %s but got %s", expectedErr, err)
-	}
+	assertNoError(err, t)
+
+	assertExpectedGorIndex(index, t)
 }
 
-// Argument scheme://host:port
-// i.e : http://localhost:9200
-func TestElasticConnectionBuildFailWithoutIndex(t *testing.T) {
-	uri := "http://localhost:9200"
-	expectedErr := new(ESUriErorr)
-
-  err, _, _, _ := parseURI(uri)
-
-	if expectedErr != err {
-		t.Errorf("Expected err %s but got %s", expectedErr, err)
-	}
-}
-
-// Argument host:port/index_name
-// i.e : localhost.local:9200/gor
+// Argument scheme://host:port/index_name
+// i.e : http://localhost:9200/gor
 func TestElasticLocalConnectionBuild(t *testing.T) {
-	uri := "http://localhost:9200/gor"
-	expectedHost := "http://localhost"
-	expectedApiPort := "9200"
-	expectedIndex := "gor"
+	uri := "http://localhost:9200/" + expectedIndex
 
-	err, host, apiPort, index := parseURI(uri)
+	err, index := parseURI(uri)
 
-	if nil != err {
-		t.Fatalf("Expected err %s but got %s", nil, err)
-	}
-	if expectedHost != host {
-		t.Fatalf("Expected host %s but got %s", expectedHost, host)
-	}
-	if expectedApiPort != apiPort {
-		t.Fatalf("Expected port %s but got %s", expectedApiPort, apiPort)
-	}
-	if expectedIndex != index {
-		t.Fatalf("Expected index %s but got %s", expectedIndex, index)
-	}
+	assertNoError(err, t)
+
+	assertExpectedGorIndex(index, t)
 }
 
-// Argument host:port/index_name
+// Argument scheme://host:port/index_name
 // i.e : http://localhost.local:9200/gor or https://localhost.local:9200/gor
 func TestElasticSimpleLocalWithSchemeConnectionBuild(t *testing.T) {
-	uri := "http://localhost.local:9200/gor"
-	expectedHost := "http://localhost.local"
-	expectedApiPort := "9200"
-	expectedIndex := "gor"
+	uri := "http://localhost.local:9200/" + expectedIndex
 
-	err, host, apiPort, index := parseURI(uri)
+	err, index := parseURI(uri)
 
-	if nil != err {
-		t.Fatalf("Expected err %s but got %s", nil, err)
-	}
-	if expectedHost != host {
-		t.Fatalf("Expected host %s but got %s", expectedHost, host)
-	}
-	if expectedApiPort != apiPort {
-		t.Fatalf("Expected port %s but got %s", expectedApiPort, apiPort)
-	}
-	if expectedIndex != index {
-		t.Fatalf("Expected index %s but got %s", expectedIndex, index)
-	}
+	assertNoError(err, t)
+
+	assertExpectedGorIndex(index, t)
 }
 
-// Argument host:port/index_name
+// Argument scheme://host:port/index_name
 // i.e : http://localhost.local:9200/gor or https://localhost.local:9200/gor
 func TestElasticSimpleLocalWithHTTPSConnectionBuild(t *testing.T) {
-	uri := "https://localhost.local:9200/gor"
-	expectedHost := "https://localhost.local"
-	expectedApiPort := "9200"
-	expectedIndex := "gor"
+	uri := "https://localhost.local:9200/" + expectedIndex
 
-	err, host, apiPort, index := parseURI(uri)
+	err, index := parseURI(uri)
 
-	if nil != err {
-		t.Fatalf("Expected err %s but got %s", nil, err)
-	}
-	if expectedHost != host {
-		t.Fatalf("Expected host %s but got %s", expectedHost, host)
-	}
-	if expectedApiPort != apiPort {
-		t.Fatalf("Expected port %s but got %s", expectedApiPort, apiPort)
-	}
-	if expectedIndex != index {
-		t.Fatalf("Expected index %s but got %s", expectedIndex, index)
-	}
+	assertNoError(err, t)
+
+	assertExpectedGorIndex(index, t)
 }
 
-// Argument host:port/index_name
+// Argument scheme://host:port/index_name
 // i.e : localhost.local:9200/pathtoElastic/gor
 func TestElasticLongPathConnectionBuild(t *testing.T) {
-	uri := "http://localhost.local:9200/pathtoElastic/gor"
-	expectedHost := "http://localhost.local"
-	expectedApiPort := "9200"
-	expectedIndex := "gor"
+	uri := "http://localhost.local:9200/pathtoElastic/" + expectedIndex
 
-	err, host, apiPort, index := parseURI(uri)
+	err, index := parseURI(uri)
 
-	if nil != err {
-		t.Fatalf("Expected err %s but got %s", nil, err)
-	}
-	if expectedHost != host {
-		t.Fatalf("Expected host %s but got %s", expectedHost, host)
-	}
-	if expectedApiPort != apiPort {
-		t.Fatalf("Expected port %s but got %s", expectedApiPort, apiPort)
-	}
-	if expectedIndex != index {
-		t.Fatalf("Expected index %s but got %s", expectedIndex, index)
-	}
+	assertNoError(err, t)
+
+	assertExpectedGorIndex(index, t)
 }
 
-// Argument host:port/index_name
+// Argument scheme://host:userinfo@port/index_name
 // i.e : http://user:password@localhost.local:9200/gor
 func TestElasticBasicAuthConnectionBuild(t *testing.T) {
-	uri := "http://user:password@localhost.local:9200/gor"
-	expectedHost := "http://localhost.local"
-	expectedApiPort := "9200"
-	expectedIndex := "gor"
+	uri := "http://user:password@localhost.local:9200/" + expectedIndex
 
-	err, host, apiPort, index := parseURI(uri)
+	err, index := parseURI(uri)
 
-	if nil != err {
-		t.Fatalf("Expected err %s but got %s", nil, err)
-	}
-	if expectedHost != host {
-		t.Fatalf("Expected host %s but got %s", expectedHost, host)
-	}
-	if expectedApiPort != apiPort {
-		t.Fatalf("Expected port %s but got %s", expectedApiPort, apiPort)
-	}
-	if expectedIndex != index {
-		t.Fatalf("Expected index %s but got %s", expectedIndex, index)
-	}
+	assertNoError(err, t)
+
+	assertExpectedGorIndex(index, t)
+}
+
+// Argument scheme://host:port/path/index_name
+// i.e : http://localhost.local:9200/path/gor or https://localhost.local:9200/path/gor
+func TestElasticComplexPathConnectionBuild(t *testing.T) {
+	uri := "http://localhost.local:9200/path/" + expectedIndex
+
+	err, index := parseURI(uri)
+
+	assertNoError(err, t)
+
+	assertExpectedGorIndex(index, t)
 }


### PR DESCRIPTION
Will fix #430 
Use elasticgo SetFromUrl() function to build connection using URI.
URI must start with scheme to avoid net package failure on URI parsing in SetFromUrl() function.