### PR TITLE
Fixed Dockerfile that fails during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:latest
-RUN wget https://github.com/buger/goreplay/releases/download/v0.16.0.2/gor_0.16.0_x64.tar.gz -o gor.tar.gz
+RUN apk update && apk add ca-certificates && update-ca-certificates && apk add openssl
+RUN wget https://github.com/buger/goreplay/releases/download/v0.16.0.2/gor_0.16.0_x64.tar.gz -O gor.tar.gz
 RUN tar xzf gor.tar.gz
 ENTRYPOINT ./gor

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ install:
 	go install $(MAC_LDFLAGS)
 
 build:
-	docker build -t gor .
+	docker build -t gor -f Dockerfile.dev .
 
 
 profile:


### PR DESCRIPTION
1. Currently this errors:
```bash
docker build -t gor .
Sending build context to Docker daemon 18.05 MB
Step 1/4 : FROM alpine:latest
 ---> 665ffb03bfae
Step 2/4 : RUN wget https://github.com/buger/goreplay/releases/download/v0.16.0.2/gor_0.16.0_x64.tar.gz -o gor.tar.gz
 ---> Running in b523ab003ccc
wget: unrecognized option: o
BusyBox v1.26.2 (2017-06-11 06:38:32 GMT) multi-call binary.

Usage: wget [-c|--continue] [--spider] [-q|--quiet] [-O|--output-document FILE]
        [--header 'header: value'] [-Y|--proxy on/off] [-P DIR]
        [-U|--user-agent AGENT] [-T SEC] URL...

Retrieve files via HTTP or FTP

        --spider        Spider mode - only check file existence
        -c              Continue retrieval of aborted transfer
        -q              Quiet
        -P DIR          Save to DIR (default .)
        -T SEC          Network read timeout is SEC seconds
        -O FILE         Save to FILE ('-' for stdout)
        -U STR          Use STR for User-Agent header
        -Y on/off       Use proxy
The command '/bin/sh -c wget https://github.com/buger/goreplay/releases/download/v0.16.0.2/gor_0.16.0_x64.tar.gz -o gor.tar.gz' returned a non-zero code: 1
```

I fixed this by adding certificates and using correct parameter (-O instead of -o) in `wget` command.

2. Also updated `make build` command that builds a container using default `Dockerfile` but other `make` targets (like `make test` etc) expect this to be a docker image build from `Dockerfile.dev`.