### PR TITLE
Filter requests using regex on base64 decoded userId:passwd

### DIFF
--- a/http_modifier_settings.go
+++ b/http_modifier_settings.go
@@ -10,14 +10,15 @@ import (
 
 // HTTPModifierConfig holds configuration options for built-in traffic modifier
 type HTTPModifierConfig struct {
-	urlNegativeRegexp     HTTPUrlRegexp
-	urlRegexp             HTTPUrlRegexp
-	urlRewrite            UrlRewriteMap
-	headerRewrite         HeaderRewriteMap
-	headerFilters         HTTPHeaderFilters
-	headerNegativeFilters HTTPHeaderFilters
-	headerHashFilters     HTTPHashFilters
-	paramHashFilters      HTTPHashFilters
+	urlNegativeRegexp      HTTPUrlRegexp
+	urlRegexp              HTTPUrlRegexp
+	urlRewrite             UrlRewriteMap
+	headerRewrite          HeaderRewriteMap
+	headerFilters          HTTPHeaderFilters
+	headerNegativeFilters  HTTPHeaderFilters
+	headerBasicAuthFilters HTTPHeaderBasicAuthFilters
+	headerHashFilters      HTTPHashFilters
+	paramHashFilters       HTTPHashFilters
 
 	params  HTTPParams
 	headers HTTPHeaders
@@ -54,6 +55,32 @@ func (h *HTTPHeaderFilters) Set(value string) error {
 
 	return nil
 }
+
+//
+// Handling of --http-basic-auth-filter option
+//
+type basicAuthFilter struct {
+	regexp *regexp.Regexp
+}
+
+// HTTPHeaderFilters holds list of headers and their regexps
+type HTTPHeaderBasicAuthFilters []basicAuthFilter
+
+func (h *HTTPHeaderBasicAuthFilters) String() string {
+	return fmt.Sprint(*h)
+}
+
+func (h *HTTPHeaderBasicAuthFilters) Set(value string) error {
+	r, err := regexp.Compile(value)
+	if err != nil {
+		return err
+	}
+
+	*h = append(*h, basicAuthFilter{regexp: r})
+
+	return nil
+}
+
 
 //
 // Handling of --http-allow-header-hash and --http-allow-param-hash options

--- a/http_modifier_test.go
+++ b/http_modifier_test.go
@@ -78,6 +78,45 @@ func TestHTTPModifierHeaderNegativeFilters(t *testing.T) {
 	}
 }
 
+func TestHTTPHeaderBasicAuthFilters(t *testing.T) {
+	filters := HTTPHeaderBasicAuthFilters{}
+	filters.Set("^customer[0-9].*")
+
+	modifier := NewHTTPModifier(&HTTPModifierConfig{
+		headerBasicAuthFilters: filters,
+	})
+
+	//Encoded UserId:Password = customer3:welcome
+	payload := []byte("POST /post HTTP/1.1\r\nContent-Length: 7\r\nAuthorization: Basic Y3VzdG9tZXIzOndlbGNvbWU=\r\n\r\na=1&b=2")
+	if len(modifier.Rewrite(payload)) == 0 {
+		t.Error("Request should pass filters")
+	}
+
+	//customer6:rest@123^TEST
+	payload = []byte("POST /post HTTP/1.1\r\nContent-Length: 88\r\nAuthorization: Basic Y3VzdG9tZXI2OnJlc3RAMTIzXlRFU1Q==\r\n\r\na=1&b=2")
+	if len(modifier.Rewrite(payload)) == 0 {
+		t.Error("Request should pass filters")
+	}	
+
+	filters = HTTPHeaderBasicAuthFilters{}
+	// Setting filter that not match our header
+	filters.Set("^(homer simpson|mickey mouse).*")
+
+	modifier = NewHTTPModifier(&HTTPModifierConfig{
+		headerBasicAuthFilters: filters,
+	})
+
+	if len(modifier.Rewrite(payload)) != 0 {
+		t.Error("Request should not pass filters")
+	}
+
+	//mickey mouse:happy123
+	payload = []byte("POST /post HTTP/1.1\r\nContent-Length: 88\r\nAuthorization: Basic bWlja2V5IG1vdXNlOmhhcHB5MTIz\r\n\r\na=1&b=2")
+	if len(modifier.Rewrite(payload)) == 0 {
+		t.Error("Request should pass filters")
+	}	
+}
+
 func TestHTTPModifierURLRewrite(t *testing.T) {
 	var url, newURL []byte
 

--- a/settings.go
+++ b/settings.go
@@ -176,6 +176,8 @@ func init() {
 
 	flag.Var(&Settings.modifierConfig.headerNegativeFilters, "http-disallow-header", "A regexp to match a specific header against. Requests with matching headers will be dropped:\n\t gor --input-raw :8080 --output-http staging.com --http-disallow-header \"User-Agent: Replayed by Gor\"")
 
+    flag.Var(&Settings.modifierConfig.headerBasicAuthFilters, "http-basic-auth-filter", "A regexp to match the decoded basic auth string against. Requests with non-matching headers will be dropped:\n\t gor --input-raw :8080 --output-http staging.com --http-basic-auth-filter \"^customer[0-9].*\"")
+
 	flag.Var(&Settings.modifierConfig.headerHashFilters, "http-header-limiter", "Takes a fraction of requests, consistently taking or rejecting a request based on the FNV32-1A hash of a specific header:\n\t gor --input-raw :8080 --output-http staging.com --http-header-imiter user-id:25%")
 	flag.Var(&Settings.modifierConfig.headerHashFilters, "output-http-header-hash-filter", "WARNING: `output-http-header-hash-filter` DEPRECATED, use `--http-header-hash-limiter` instead")
 


### PR DESCRIPTION
Hello, we have a need to filter using the HTTP Basic Auth header. Specifically, using a regex to match the "UserId" portion of the header.

So, I made a small change to extract the basic auth header, base64 decode the `userid:passwd` portion of the string and then run it against the given regex.

Usage snippet:  `--http-basic-auth-filter "^customer[0-9].*"`

Thanks.