### PR TITLE
fix issue #476 file rotation

### DIFF
--- a/output_file.go
+++ b/output_file.go
@@ -185,9 +185,10 @@ func (o *FileOutput) Write(data []byte) (n int, err error) {
 		meta := payloadMeta(data)
 		o.currentID = meta[1]
 		o.payloadType = meta[0]
-		o.updateName()
 	}
-
+	
+	o.updateName()
+	
 	if o.file == nil || o.currentName != o.file.Name() {
 		o.mu.Lock()
 		o.Close()


### PR DESCRIPTION
It seems the problem is caused by the following code in method "Write" of output_file.go.

```go
	if o.requestPerFile {
		meta := payloadMeta(data)
		o.currentID = meta[1]
		o.payloadType = meta[0]
		o.updateName()
	}
```

So o.updateName() in which the new file name is determined is called only when the request per file config is true. Move o.updateName() to the outside should fix that.