### PR TITLE
Improve handling for 100-continue requests for clients ignoring response

### DIFF
--- a/proto/proto.go
+++ b/proto/proto.go
@@ -467,7 +467,7 @@ func Status(payload []byte) []byte {
 }
 
 var httpMethods []string = []string{
-	"GET ", "OPTI", "HEAD", "POST", "PUT ", "DELE", "TRAC", "CONN", "PATC" /* custom methods */, "BAN", "PURG",
+	"GET ", "OPTI", "HEAD", "POST", "PUT ", "DELE", "TRAC", "CONN", "PATC" /* custom methods */, "BAN ", "PURG", "PROP", "MKCO", "COPY", "MOVE", "LOCK", "UNLO",
 }
 
 func IsHTTPPayload(payload []byte) bool {

--- a/raw_socket_listener/tcp_message.go
+++ b/raw_socket_listener/tcp_message.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/buger/goreplay/proto"
@@ -478,4 +479,12 @@ func (t *TCPMessage) ID() tcpID {
 
 func (t *TCPMessage) IP() net.IP {
 	return net.IP(t.packets[0].Addr)
+}
+
+func (t *TCPMessage) String() string {
+	return strings.Join([]string{
+		"Len packets: " + strconv.Itoa(len(t.packets)),
+		"Data size:" + strconv.Itoa(len(t.Bytes())),
+		"Data:" + string(t.Bytes()),
+	}, "\n")
 }


### PR DESCRIPTION
Some clients, even if have `Expect: 100-continue` in request, start
sending data without waiting for approval from the server. More over, there
are cases when response “100 Continue” is received, client changes TCP
seq, and following requests start having valid sequences, based on
response one.

This change should address this bugs. I also added packet generation helpers to the tests, which makes defining packet chains way more obvious.

As small addition extended list of HTTP methods, to fully support
WebDAV.