### PR TITLE
Fix 100 continue

### DIFF
--- a/http_client.go
+++ b/http_client.go
@@ -181,6 +181,7 @@ func (c *HTTPClient) Send(data []byte) (response []byte, err error) {
 	if _, err = c.conn.Write(data); err != nil {
 		Debug("[HTTPClient] Write error:", err, c.baseURL)
 		response = errorPayload(HTTP_TIMEOUT)
+		c.Disconnect()
 		return
 	}
 


### PR DESCRIPTION
We had problems replaying feeds with 100 responses. There were three things we tripped up on, done as three commits below. An example of 100 Continue

goreplay->client : POST with Expect: 100-continue
client->goreplay: HTTP/1.1 100
client->goreplay: HTTP/1.1 200

To discuss them individually:

1. "Don't loose bytes checking connection isAlive".
On receiving a 100 code from downstream, the code would exit from Send, potentially leave a 200 response in the buffer. Next time in, the "isAlive" would read the "H" of "HTTP" from the 200 response. Then the code would read the remaining response "TTP/" etc. and then blow up. Attempt to solve this by reading the byte in to the receive buffer and not throwing it away.

2. "Soak up any 1xx return codes, catching up to the real return code"
When using Expect: 100-continue, each request may receive more than one response (0 or more 100-continue + the real response). Send will only read one response per request, thus falling further behind when the connection is reused for the next Send. Attempt to solve this by throwing away the 1xx codes, pretending we never got them.

3.  "On write error, disconnect to force a new connection"
When 1 above was implemented and while testing, if there were problems in the implementation of 2 above then it was noticed that the code would sometimes get stuck trying to write to a dead connection. The connection would appear to be alive, as there would be bytes available from the client, but the downstream client had closed their receiving side. Attempt to solve by forcing a disconnect.