### PR TITLE
FIX: miscalculation of the mean value

### DIFF
--- a/gor_stat.go
+++ b/gor_stat.go
@@ -40,7 +40,7 @@ func (s *GorStat) Write(latest int) {
 			s.max = latest
 		}
 		if latest != 0 {
-			s.mean = (s.mean + latest) / 2
+			s.mean = ((s.mean * s.count) + latest) / (s.count + 1)
 		}
 		s.latest = latest
 		s.count = s.count + 1


### PR DESCRIPTION
Test

```go
func TestWrite(t *testing.T) {

	Settings.stats = true
	stat := NewGorStat("test")

	numbers := []int{10, 20, 30, 40, 50}

	for _, num := range numbers {
		stat.Write(num)
	}

	log.Println("mean: " + strconv.Itoa(mean))
	time.Sleep(2 * time.Second)

}
```