### PR TITLE
Exporting the `httpHeaders` method

### DIFF
--- a/middleware/middleware.js
+++ b/middleware/middleware.js
@@ -402,7 +402,8 @@ module.exports = {
     httpCookie: httpCookie,
     setHttpCookie: setHttpCookie,
     test: testRunner,
-    benchmark: testBenchmark
+    benchmark: testBenchmark,
+    httpHeaders: httpHeaders
 }
 
 


### PR DESCRIPTION
This method export was missing from last commit (when `httpHeaders` was created)

Reference: https://github.com/buger/goreplay/pull/580