### PR TITLE
Remove unused "copy"

### DIFF
--- a/raw_socket_listener/listener.go
+++ b/raw_socket_listener/listener.go
@@ -682,12 +682,6 @@ func (t *Listener) readRAWSocket() {
 }
 
 func (t *Listener) buildPacket(packetSrcIP []byte, packetData []byte, timestamp time.Time) *packet {
-	copyPacketSrcIP := make([]byte, 16)
-	copyPacketData := make([]byte, len(packetData))
-
-	copy(copyPacketSrcIP, packetSrcIP)
-	copy(copyPacketData, packetSrcIP)
-
 	return &packet{
 		srcIP:     packetSrcIP,
 		data:      packetData,


### PR DESCRIPTION
[commit fa0e96b7efe0c345f230286ac09b2aaf558ee64e    buildPacket](https://github.com/buger/goreplay/commit/fa0e96b7efe0c345f230286ac09b2aaf558ee64e#diff-19150059c422de82853e004a101150f7R639)   
This `func buildPacket` use "copy", but two variables named "copyPacketSrcIP” and “copyPacketData" are “unused"  in actually. So remove them.