### PR TITLE
Fix golint URL in Dockerfile.dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,7 +13,7 @@ RUN apt-get install oracle-java8-installer -y
 RUN apt-get install flex bison -y
 RUN wget http://www.tcpdump.org/release/libpcap-1.8.1.tar.gz && tar xzf libpcap-1.8.1.tar.gz && cd libpcap-1.8.1 && ./configure && make install
 RUN go get github.com/google/gopacket
-RUN go get -u github.com/golang/lint/golint
+RUN go get -u golang.org/x/lint/golint
 
 WORKDIR /go/src/github.com/buger/goreplay/
 ADD . /go/src/github.com/buger/goreplay/


### PR DESCRIPTION
A recent patch to golint requires the `golang.org/x/lint/golint` path to be used (described [here](https://github.com/golang/lint/issues/415)). This was breaking the `Dockerfile.dev` build that was being run by the `make build` command. Updating the URL fixes the build. ✨ 

Thanks for your hard work on this tool, it's been a huge help!