### PR TITLE
[doc] Updated commands used to enable run of gor for non-root users

### DIFF
--- a/docs/Running-as-non-root-user.md
+++ b/docs/Running-as-non-root-user.md
@@ -1,12 +1,12 @@
 You can enable Gor for non-root users in a secure method by using the following commands
 
 ``` 
-# Following commands assume that you put `gor` binary to /usr/local/bin
-add gor
-addgroup <username> gor
-chgrp gor /usr/local/bin/gor
-chmod 0750 /usr/local/bin/gor
-setcap "cap_net_raw,cap_net_admin+eip" /usr/local/bin/gor
+# Following commands assume that you put `goreplay` binary to /usr/local/bin and <username> is the owner gor binary
+addgroup gor
+adduser <username> gor
+chgrp gor /usr/local/bin/goreplay
+chmod 0750 /usr/local/bin/goreplay
+setcap "cap_net_raw,cap_net_admin+eip" /usr/local/bin/goreplay
 ```
  
 As a brief explanation of the above.


### PR DESCRIPTION


Currently the first 2 commands used to create the gor group and add user <username> to it don't work because add command don't exist in linux and addgroup can't be used to add a user to a specific group. These commands has been replaced by adduser & addgroup.

I also notice that strating the gor binary as non-root user only works after following these steps if the gor binary inside /usr/local/bin belongs at the beginnning to user <username> so i add it as prerequesite.

Thanks