### PR TITLE
Add support for building snaps

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,39 @@
+name: goreplay
+version: '1.0'
+summary: GoReplay is an open-source tool for capturing and replaying live HTTP traffic 
+description: |
+  GoReplay is an open-source tool for capturing and replaying 
+  live HTTP traffic into a test environment in order to continuously 
+  test your system with real data. It can be used to increase confidence 
+  in code deployments, configuration changes and infrastructure changes. 
+grade: stable
+confinement: strict
+base: core18
+parts:
+  goreplay:
+    plugin: go
+    source: https://github.com/buger/goreplay.git
+    go-importpath: github.com/buger/goreplay
+    build-packages:
+      - build-essential
+      - libpcap-dev
+    stage-packages:
+      - libpcap0.8
+
+apps:
+  goreplay:
+    command: bin/goreplay
+    daemon: simple
+    restart-condition: on-abnormal
+    plugs:
+      - home
+      - network
+      - network-bind
+      - network-control
+      - network-observe
+      - netlink-connector
+      - netlink-audit
+      - bluetooth-control
+      - firewall-control
+      - x11
+      


### PR DESCRIPTION
I've created this PR to request support for building a snap package of goreplay.

Snaps are cross-distro Linux software packages, supported on LTS and non-LTS Ubuntu, as well as Debian, Manjaro, Fedora, OpenSUSE, Arch, and many others distributions. Making a snap of goreplay will enable you to provide automatic updates on your schedule to your users via the snap store.

If you accept this PR, you can use snapcraft locally, your CI system or our free build system (build.snapcraft.io) to create snaps and upload to the Snap Store (snapcraft.io/store).

To test this PR locally, I used a stock Ubuntu 18.04 system. I built the goreplay snap from sources - I was able to create raw sockets, and it has bluetooth control, too. I did not build goreplay with support for USB adapters, but that can also be added quite easily. The snap has been compiled with libpcap0.8, and it also has X11 support. Again, snaps support multiple interfaces, so this can be extended if needed.

My build and test was as follows:

snap install snapcraft --classic --beta
git clone https://github.com/igorljubuncic/goreplay.git
cd goreplay
git checkout add-snapcraft
snapcraft

The last command will generate a <goreplay-version>.snap file, something like goreplay_1.0_amd64.snap.

This snap can be installed and tested locally with:

snap install goreplay_1.0_amd64.snap --dangerous

The --dangerous flag is necessary because the app (snap) hasn’t gone through the snap store review process and is not signed.

Once installed, the goreplay command can be executed, e.g.: snap run goreplay <options>.

If landed, you will need to complete a couple more steps:

- Register a developer account in the snap store https://snapcraft.io/account.
- Register the goreplay name in the store. 

snapcraft login
snapcraft register

- Upload a built snap to the store. The store supports multiple risk levels as “channels” with the 'edge' channel typically used to host the latest build from git master. Stable is where stable releases are pushed. Optionally, beta and candidate channels can also be used, for different levels of stability and testing.

snapcraft push goreplay_1.0_amd64.snap --release edge

- Test installing on a clean machine

snap install goreplay --edge

After you have completed your tests, you can push a stable release to the stable channel, update the store page, and promote the application online. We can help there, and we'd be happy to feature your application in our store.