### PR TITLE
More robust chunked encoding finished check.

### DIFF
--- a/raw_socket_listener/tcp_message.go
+++ b/raw_socket_listener/tcp_message.go
@@ -199,7 +199,7 @@ func (t *TCPMessage) checkSeqIntegrity() {
 
 var bEmptyLine = []byte("\r\n\r\n")
 var bBR = []byte("\r\n")
-var bChunkEnd = []byte("0\r\n\r\n")
+var bChunkEnd = []byte("\r\n0\r\n\r\n")
 
 func (t *TCPMessage) updateHeadersPacket() {
 	if len(t.packets) == 1 {


### PR DESCRIPTION
Fix for infrequent false positive seeing the end of chunks in production. Obviously it isn't foolproof, but it is significantly better in our use case.