### PR TITLE
Add setting for pcap immediate mode to fix timeouts waiting for packets

### DIFF
--- a/input_raw.go
+++ b/input_raw.go
@@ -81,7 +81,7 @@ func (i *RAWInput) listen(address string) {
 		log.Fatal("input-raw: error while parsing address", err)
 	}
 
-	i.listener = raw.NewListener(host, port, i.engine, i.trackResponse, i.expire, i.bpfFilter, i.timestampType, i.bufferSize)
+	i.listener = raw.NewListener(host, port, i.engine, i.trackResponse, i.expire, i.bpfFilter, i.timestampType, i.bufferSize, Settings.inputRAWImmediateMode)
 
 	ch := i.listener.Receiver()
 

--- a/raw_socket_listener/listener.go
+++ b/raw_socket_listener/listener.go
@@ -74,6 +74,7 @@ type Listener struct {
 
 	bpfFilter     string
 	timestampType string
+	immediateMode bool
 
 	bufferSize int
 
@@ -98,7 +99,7 @@ const (
 )
 
 // NewListener creates and initializes new Listener object
-func NewListener(addr string, port string, engine int, trackResponse bool, expire time.Duration, bpfFilter string, timestampType string, bufferSize int) (l *Listener) {
+func NewListener(addr string, port string, engine int, trackResponse bool, expire time.Duration, bpfFilter string, timestampType string, bufferSize int, immediateMode bool) (l *Listener) {
 	l = &Listener{}
 
 	l.packetsChan = make(chan *packet, 10000)
@@ -114,6 +115,7 @@ func NewListener(addr string, port string, engine int, trackResponse bool, expir
 	l.trackResponse = trackResponse
 	l.bpfFilter = bpfFilter
 	l.timestampType = timestampType
+	l.immediateMode = immediateMode
 	l.bufferSize = bufferSize
 
 	l.addr = addr
@@ -358,7 +360,10 @@ func (t *Listener) readPcap() {
 
 			inactive.SetTimeout(t.messageExpire)
 			inactive.SetPromisc(true)
-
+			inactive.SetImmediateMode(t.immediateMode)
+			if t.immediateMode {
+				log.Println("Setting immediate mode")
+			}
 			if t.bufferSize > 0 {
 				inactive.SetBufferSize(t.bufferSize)
 			}

--- a/settings.go
+++ b/settings.go
@@ -55,6 +55,7 @@ type AppSettings struct {
 	inputRAWExpire        time.Duration
 	inputRAWBpfFilter     string
 	inputRAWTimestampType string
+	inputRAWImmediateMode bool
 	inputRawBufferSize    int
 
 	middleware string
@@ -133,6 +134,7 @@ func init() {
 	flag.StringVar(&Settings.inputRAWBpfFilter, "input-raw-bpf-filter", "", "BPF filter to write custom expressions. Can be useful in case of non standard network interfaces like tunneling or SPAN port. Example: --input-raw-bpf-filter 'dst port 80'")
 
 	flag.StringVar(&Settings.inputRAWTimestampType, "input-raw-timestamp-type", "", "Possible values: PCAP_TSTAMP_HOST, PCAP_TSTAMP_HOST_LOWPREC, PCAP_TSTAMP_HOST_HIPREC, PCAP_TSTAMP_ADAPTER, PCAP_TSTAMP_ADAPTER_UNSYNCED. This values not supported on all systems, GoReplay will tell you available values of you put wrong one.")
+	flag.BoolVar(&Settings.inputRAWImmediateMode, "input-raw-immediate-mode", false, "Set pcap interface to immediate mode.")
 
 	flag.IntVar(&Settings.inputRawBufferSize, "input-raw-buffer-size", 0, "Controls size of the OS buffer (in bytes) which holds packets until they dispatched. Default value depends by system: in Linux around 2MB. If you see big package drop, increase this value.")
 


### PR DESCRIPTION
This helped in production (on VMs) to not drop packets. It is an option that is required to be switched on, i.e. I've not changed default behaviour.