### PR TITLE
Add setting for copyBufferSize, defaults to 5 Mbytes

### DIFF
--- a/emitter.go
+++ b/emitter.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"io"
+	"log"
 	"time"
 )
 
@@ -47,7 +48,7 @@ func Start(stop chan int) {
 
 // CopyMulty copies from 1 reader to multiple writers
 func CopyMulty(src io.Reader, writers ...io.Writer) (err error) {
-	buf := make([]byte, 5*1024*1024)
+	buf := make([]byte, Settings.copyBufferSize)
 	wIndex := 0
 	modifier := NewHTTPModifier(&Settings.modifierConfig)
 	filteredRequests := make(map[string]time.Time)
@@ -61,7 +62,6 @@ func CopyMulty(src io.Reader, writers ...io.Writer) (err error) {
 		if nr > 500 {
 			_maxN = 500
 		}
-
 		if nr > 0 && len(buf) > nr {
 			payload := buf[:nr]
 			meta := payloadMeta(payload)
@@ -72,6 +72,10 @@ func CopyMulty(src io.Reader, writers ...io.Writer) (err error) {
 				continue
 			}
 			requestID := string(meta[1])
+
+			if nr >= 5*1024*1024 {
+				log.Println("INFO: Large packet... We received ", len(payload), " bytes from ", src)
+			}
 
 			if Settings.debug {
 				Debug("[EMITTER] input:", string(payload[0:_maxN]), nr, "from:", src)
@@ -126,7 +130,8 @@ func CopyMulty(src io.Reader, writers ...io.Writer) (err error) {
 					dst.Write(payload)
 				}
 			}
-
+		} else if nr > 0 {
+			log.Println("WARN: Packet", nr, "bytes is too large to process. Consider increasing --copy-buffer-size")
 		}
 		if er == io.EOF {
 			break

--- a/settings.go
+++ b/settings.go
@@ -55,6 +55,7 @@ type AppSettings struct {
 	inputRAWExpire        time.Duration
 	inputRAWBpfFilter     string
 	inputRAWTimestampType string
+	copyBufferSize        int
 	inputRawBufferSize    int
 
 	middleware string
@@ -133,6 +134,7 @@ func init() {
 	flag.StringVar(&Settings.inputRAWBpfFilter, "input-raw-bpf-filter", "", "BPF filter to write custom expressions. Can be useful in case of non standard network interfaces like tunneling or SPAN port. Example: --input-raw-bpf-filter 'dst port 80'")
 
 	flag.StringVar(&Settings.inputRAWTimestampType, "input-raw-timestamp-type", "", "Possible values: PCAP_TSTAMP_HOST, PCAP_TSTAMP_HOST_LOWPREC, PCAP_TSTAMP_HOST_HIPREC, PCAP_TSTAMP_ADAPTER, PCAP_TSTAMP_ADAPTER_UNSYNCED. This values not supported on all systems, GoReplay will tell you available values of you put wrong one.")
+	flag.IntVar(&Settings.copyBufferSize, "copy-buffer-size", 5*1024*1024, "Set the buffer size for an individual request (default 5M)")
 
 	flag.IntVar(&Settings.inputRawBufferSize, "input-raw-buffer-size", 0, "Controls size of the OS buffer (in bytes) which holds packets until they dispatched. Default value depends by system: in Linux around 2MB. If you see big package drop, increase this value.")
 


### PR DESCRIPTION
We require a larger copyBufferSize in production (~30M). Rather than change a sensible default, it is now an option.