### PR TITLE
Configurable override snaplen to 64k for virtualized environments

### DIFF
--- a/input_raw.go
+++ b/input_raw.go
@@ -81,7 +81,7 @@ func (i *RAWInput) listen(address string) {
 		log.Fatal("input-raw: error while parsing address", err)
 	}
 
-	i.listener = raw.NewListener(host, port, i.engine, i.trackResponse, i.expire, i.bpfFilter, i.timestampType, i.bufferSize)
+	i.listener = raw.NewListener(host, port, i.engine, i.trackResponse, i.expire, i.bpfFilter, i.timestampType, i.bufferSize, Settings.inputRAWOverrideSnapLen)
 
 	ch := i.listener.Receiver()
 

--- a/raw_socket_listener/listener.go
+++ b/raw_socket_listener/listener.go
@@ -74,6 +74,7 @@ type Listener struct {
 
 	bpfFilter     string
 	timestampType string
+	overrideSnapLen bool
 
 	bufferSize int
 
@@ -98,7 +99,7 @@ const (
 )
 
 // NewListener creates and initializes new Listener object
-func NewListener(addr string, port string, engine int, trackResponse bool, expire time.Duration, bpfFilter string, timestampType string, bufferSize int) (l *Listener) {
+func NewListener(addr string, port string, engine int, trackResponse bool, expire time.Duration, bpfFilter string, timestampType string, bufferSize int, overrideSnapLen bool) (l *Listener) {
 	l = &Listener{}
 
 	l.packetsChan = make(chan *packet, 10000)
@@ -115,6 +116,7 @@ func NewListener(addr string, port string, engine int, trackResponse bool, expir
 	l.bpfFilter = bpfFilter
 	l.timestampType = timestampType
 	l.bufferSize = bufferSize
+	l.overrideSnapLen = overrideSnapLen
 
 	l.addr = addr
 	_port, _ := strconv.Atoi(port)
@@ -349,7 +351,7 @@ func (t *Listener) readPcap() {
 				}
 			}
 
-			if it, err := net.InterfaceByName(device.Name); err == nil {
+			if it, err := net.InterfaceByName(device.Name); err == nil && !t.overrideSnapLen {
 				// Auto-guess max length of packet to capture
 				inactive.SetSnapLen(it.MTU + 68*2)
 			} else {

--- a/raw_socket_listener/listener_test.go
+++ b/raw_socket_listener/listener_test.go
@@ -12,7 +12,7 @@ import (
 func TestRawListenerInput(t *testing.T) {
 	var req, resp *TCPMessage
 
-	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0)
+	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0, false)
 	defer listener.Close()
 
 	reqPacket := buildPacket(true, 1, 1, []byte("GET / HTTP/1.1\r\n\r\n"), time.Now())
@@ -77,7 +77,7 @@ func responsePacket(prev *TCPPacket, payload []byte) *TCPPacket {
 }
 
 func TestHEADRequestNoBody(t *testing.T) {
-	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0)
+	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0, false)
 	defer listener.Close()
 
 	reqPacket := firstPacket([]byte("HEAD / HTTP/1.1\r\nContent-Length: 0\r\n\r\n"))
@@ -111,7 +111,7 @@ func TestHEADRequestNoBody(t *testing.T) {
 }
 
 func TestSingleAck100Continue(t *testing.T) {
-	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0)
+	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0, false)
 	defer listener.Close()
 
 	reqPacket1 := firstPacket([]byte("POST / HTTP/1.1\r\nExpect: 100-continue\r\nContent-Length: 4\r\n\r\n"))
@@ -130,7 +130,7 @@ func TestSingleAck100Continue(t *testing.T) {
 }
 
 func Test100ContinueWithoutWaiting(t *testing.T) {
-	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0)
+	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0, false)
 	defer listener.Close()
 
 	req1 := firstPacket([]byte("POST / HTTP/1.1\r\nExpect: 100-continue\r\nContent-Length: 4\r\n\r\n"))
@@ -146,7 +146,7 @@ func Test100ContinueWithoutWaiting(t *testing.T) {
 
 // Client first sends data without waiting 100-continue, but once response received, generate packets based on Ack payload
 func Test100ContinueMixed(t *testing.T) {
-	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0)
+	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0, false)
 	defer listener.Close()
 
 	req1 := firstPacket([]byte("POST / HTTP/1.1\r\nExpect: 100-continue\r\nContent-Length: 12\r\n\r\n"))
@@ -164,7 +164,7 @@ func Test100ContinueMixed(t *testing.T) {
 }
 
 func TestDoubleAck100Continue(t *testing.T) {
-	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0)
+	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0, false)
 	defer listener.Close()
 
 	reqPacket1 := firstPacket([]byte("POST / HTTP/1.1\r\nExpect: 100-continue\r\nContent-Length: 4\r\n\r\n"))
@@ -187,7 +187,7 @@ func TestDoubleAck100Continue(t *testing.T) {
 func TestRawListenerInputResponseByClose(t *testing.T) {
 	var req, resp *TCPMessage
 
-	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0)
+	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0, false)
 	defer listener.Close()
 
 	reqPacket := buildPacket(true, 1, 1, []byte("GET / HTTP/1.1\r\n\r\n"), time.Now())
@@ -227,7 +227,7 @@ func TestRawListenerInputResponseByClose(t *testing.T) {
 func TestRawListenerInputWithoutResponse(t *testing.T) {
 	var req *TCPMessage
 
-	listener := NewListener("", "0", EnginePcap, false, 10*time.Millisecond, "", "", 0)
+	listener := NewListener("", "0", EnginePcap, false, 10*time.Millisecond, "", "", 0, false)
 	defer listener.Close()
 
 	reqPacket := buildPacket(true, 1, 1, []byte("GET / HTTP/1.1\r\n\r\n"), time.Now())
@@ -249,7 +249,7 @@ func TestRawListenerInputWithoutResponse(t *testing.T) {
 func TestRawListenerResponse(t *testing.T) {
 	var req, resp *TCPMessage
 
-	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0)
+	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0, false)
 	defer listener.Close()
 
 	reqPacket := firstPacket([]byte("GET / HTTP/1.1\r\n\r\n"))
@@ -297,7 +297,7 @@ func get100ContinuePackets() (req []*TCPPacket, resp []*TCPPacket) {
 }
 
 func TestShort100Continue(t *testing.T) {
-	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0)
+	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0, false)
 	defer listener.Close()
 
 	req, resp := get100ContinuePackets()
@@ -309,7 +309,7 @@ func TestShort100Continue(t *testing.T) {
 
 // Response comes before Request
 func Test100ContinueWrongOrder(t *testing.T) {
-	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0)
+	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0, false)
 	defer listener.Close()
 
 	req, resp := get100ContinuePackets()
@@ -462,7 +462,7 @@ func permutation(n int, list []*TCPPacket) []*TCPPacket {
 
 // Response comes before Request
 func TestRawListenerChunkedWrongOrder(t *testing.T) {
-	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0)
+	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0, false)
 	defer listener.Close()
 
 	reqPacket1 := firstPacket([]byte("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\nExpect: 100-continue\r\n\r\n"))
@@ -532,7 +532,7 @@ func getMessage() []*TCPPacket {
 
 // Response comes before Request
 func TestRawListenerBench(t *testing.T) {
-	l := NewListener("", "0", EnginePcap, true, 200*time.Millisecond, "", "", 0)
+	l := NewListener("", "0", EnginePcap, true, 200*time.Millisecond, "", "", 0, false)
 	defer l.Close()
 
 	// Should re-construct message from all possible combinations
@@ -583,7 +583,7 @@ func TestRawListenerBench(t *testing.T) {
 
 func TestResponseZeroContentLength(t *testing.T) {
 	var req, resp *TCPMessage
-	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0)
+	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0, false)
 	defer listener.Close()
 
 	reqPacket := firstPacket([]byte("POST /api/setup/install HTTP/1.1\r\nHost: localhost:22936\r\nUser-Agent: curl/7.57.0\r\nAccept: */*\r\nContent-Length: 0\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\n"))

--- a/settings.go
+++ b/settings.go
@@ -56,6 +56,7 @@ type AppSettings struct {
 	inputRAWBpfFilter     string
 	inputRAWTimestampType string
 	inputRawBufferSize    int
+	inputRAWOverrideSnapLen bool
 
 	middleware string
 
@@ -133,6 +134,7 @@ func init() {
 	flag.StringVar(&Settings.inputRAWBpfFilter, "input-raw-bpf-filter", "", "BPF filter to write custom expressions. Can be useful in case of non standard network interfaces like tunneling or SPAN port. Example: --input-raw-bpf-filter 'dst port 80'")
 
 	flag.StringVar(&Settings.inputRAWTimestampType, "input-raw-timestamp-type", "", "Possible values: PCAP_TSTAMP_HOST, PCAP_TSTAMP_HOST_LOWPREC, PCAP_TSTAMP_HOST_HIPREC, PCAP_TSTAMP_ADAPTER, PCAP_TSTAMP_ADAPTER_UNSYNCED. This values not supported on all systems, GoReplay will tell you available values of you put wrong one.")
+	flag.BoolVar(&Settings.inputRAWOverrideSnapLen, "input-raw-override-snaplen", false, "Override the capture snaplen to be 64k. Required for some Virtualized environments")
 
 	flag.IntVar(&Settings.inputRawBufferSize, "input-raw-buffer-size", 0, "Controls size of the OS buffer (in bytes) which holds packets until they dispatched. Default value depends by system: in Linux around 2MB. If you see big package drop, increase this value.")
 


### PR DESCRIPTION
Option to override snaplen. We need to do this to avoid data loss when running on OpenStack VMs as we can receive packets much bigger than our MTU. The default is not changed.

Should fix https://github.com/buger/goreplay/issues/647