### PR TITLE
Allow commons tgzs to be cached

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -16,9 +16,11 @@ RUN go get github.com/google/gopacket
 RUN go get -u github.com/golang/lint/golint
 
 WORKDIR /go/src/github.com/buger/goreplay/
-ADD . /go/src/github.com/buger/goreplay/
 
 RUN wget http://archive.apache.org/dist/commons/io/binaries/commons-io-2.4-bin.tar.gz && tar xzf commons-io-2.4-bin.tar.gz && cd commons-io-2.4 && mv commons-io-2.4.jar /tmp/
 RUN wget http://archive.apache.org/dist/commons/codec/binaries/commons-codec-1.9-bin.tar.gz && tar xzf commons-codec-1.9-bin.tar.gz
+
+ADD . /go/src/github.com/buger/goreplay/
+
 RUN javac -cp commons-io-2.4/commons-io-2.4.jar -cp commons-codec-1.9/commons-codec-1.9.jar ./examples/middleware/echo.java
 RUN go get


### PR DESCRIPTION
Speeds up dev builds considerably for me when on poor network connections.