### PR TITLE
Update README

### DIFF
--- a/middleware/README.md
+++ b/middleware/README.md
@@ -4,7 +4,7 @@ GoReplay support protocol for writing middleware in any language, which allows y
 
 To simplify middleware creation we provide packages for NodeJS and Go (upcoming).
 
-If you want to get access to original and replayed responses, do not forget adding `--output-http-track-respose` and `--input-raw-track-response` options.
+If you want to get access to original and replayed responses, do not forget adding `--output-http-track-response` and `--input-raw-track-response` options.
 
 ## NodeJS
 


### PR DESCRIPTION
very little detail but 
at line 7 the argument
>--output-http-track-respose

didn't exist and should be 
>--output-http-track-response