### PR TITLE
Add input-file-max-wait parameter

### DIFF
--- a/input_file.go
+++ b/input_file.go
@@ -105,16 +105,18 @@ type FileInput struct {
 	readers     []*fileInputReader
 	speedFactor float64
 	loop        bool
+	maxWait     time.Duration
 }
 
 // NewFileInput constructor for FileInput. Accepts file path as argument.
-func NewFileInput(path string, loop bool) (i *FileInput) {
+func NewFileInput(path string, loop bool, maxWait time.Duration) (i *FileInput) {
 	i = new(FileInput)
-	i.data = make(chan []byte, 1000)
+	i.data = make(chan []byte, 8000)
 	i.exit = make(chan bool, 1)
 	i.path = path
 	i.speedFactor = 1
 	i.loop = loop
+	i.maxWait = maxWait
 
 	if err := i.init(); err != nil {
 		return
@@ -208,6 +210,10 @@ func (i *FileInput) emit() {
 		if lastTime != -1 {
 			diff := reader.timestamp - lastTime
 			lastTime = reader.timestamp
+
+			if diff > i.maxWait.Nanoseconds() {
+				diff = i.maxWait.Nanoseconds()
+			}
 
 			if i.speedFactor != 1 {
 				diff = int64(float64(diff) / i.speedFactor)

--- a/plugins.go
+++ b/plugins.go
@@ -118,7 +118,7 @@ func InitPlugins() {
 	}
 
 	for _, options := range Settings.inputFile {
-		registerPlugin(NewFileInput, options, Settings.inputFileLoop)
+		registerPlugin(NewFileInput, options, Settings.inputFileLoop, Settings.inputFileMaxWait)
 	}
 
 	for _, options := range Settings.outputFile {

--- a/settings.go
+++ b/settings.go
@@ -74,6 +74,8 @@ type AppSettings struct {
 
 	inputKafkaConfig  KafkaConfig
 	outputKafkaConfig KafkaConfig
+
+	inputFileMaxWait  time.Duration
 }
 
 // Settings holds Gor configuration
@@ -114,6 +116,7 @@ func init() {
 
 	flag.Var(&Settings.inputFile, "input-file", "Read requests from file: \n\tgor --input-file ./requests.gor --output-http staging.com")
 	flag.BoolVar(&Settings.inputFileLoop, "input-file-loop", false, "Loop input files, useful for performance testing.")
+	flag.DurationVar(&Settings.inputFileMaxWait, "input-file-max-wait", time.Duration(500000), "Max duration to wait between requests, default: 0.5 msec.")
 
 	flag.Var(&Settings.outputFile, "output-file", "Write incoming requests to file: \n\tgor --input-raw :80 --output-file ./requests.gor")
 	flag.DurationVar(&Settings.outputFileConfig.flushInterval, "output-file-flush-interval", time.Second, "Interval for forcing buffer flush to the file, default: 1s.")


### PR DESCRIPTION
Its default is set to 0.5 milliseconds and it's used to limit how long we sleep between requests read in from file input.

We noticed that when HTTP requests are captured to file they can be out-of-order, and this sometimes generated unusually long time difference bet two requests that're consecutive in the file.  A 1.5 second capture of 1000 requests sometimes would have a time diff of > 1 second between two requests.  This resulted in very very slow playback from file.

We also increased the FileInput buffer size from 1000 bytes to 8000 bytes, since we see most of our requests have way more than 1K bytes.

See also https://github.com/buger/goreplay/issues/680