### PR TITLE
it is necessary to lock output-file

### DIFF
--- a/output_file.go
+++ b/output_file.go
@@ -213,8 +213,10 @@ func (o *FileOutput) Write(data []byte) (n int, err error) {
 		o.mu.Unlock()
 	}
 
+	o.mu.Lock()
 	o.writer.Write(data)
 	o.writer.Write([]byte(payloadSeparator))
+	o.mu.Unlock()
 
 	o.totalFileSize += int64(len(data) + len(payloadSeparator))
 	o.queueLength++


### PR DESCRIPTION
If there are multiple inputs, the file would be disordered.
In my case, I run 'gor -input-file a.gor -output-http http://127.0.0.1 -output-file b.gor -output-http-track-response' and it is possible to see some chunks of b.gor end without seperator.