### PR TITLE
bugfix:fix the bug that middleware will return illegal http body when…

### DIFF
--- a/middleware/middleware.js
+++ b/middleware/middleware.js
@@ -715,6 +715,12 @@ function TEST_httpBody() {
     if (body != "hello") {
         fail(`'${body}' != 'hello'`)
     }
+
+    const exampleInvalidPayload = "Invalid HTTP Response by Network issue";
+    let invalidBody = httpBody(Buffer.from(exampleInvalidPayload));
+    if (invalidBody != null) {
+        fail(`'${invalidBody}' != 'null'`)
+    }
 }
 
 function TEST_setHttpBody() {

--- a/middleware/middleware.js
+++ b/middleware/middleware.js
@@ -335,7 +335,12 @@ function deleteHttpHeader(payload, name) {
 }
 
 function httpBody(payload) {
-    return payload.slice(payload.indexOf("\r\n\r\n") + 4, payload.length);
+    let bodyIndex = payload.indexOf("\r\n\r\n");
+    if (-1 != bodyIndex){
+        return payload.slice(bodyIndex + 4, payload.length);   
+    } else {
+        return null;
+    }
 }
 
 function setHttpBody(payload, newBody) {


### PR DESCRIPTION
… http body is empty

If the http body is empty. The httpBody function will return HTTP header content from index 3. This is unexpected.
Function caller also cannot tell whether the httpbody is empty or not.