### PR TITLE
Bump Dockerfile to v1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:latest as builder
 RUN apk add --no-cache ca-certificates openssl
-RUN wget https://github.com/buger/goreplay/releases/download/v0.16.1/gor_0.16.1_x64.tar.gz -O gor.tar.gz
+RUN wget https://github.com/buger/goreplay/releases/download/v1.0.0/gor_1.0.0_x64.tar.gz -O gor.tar.gz
 RUN tar xzf gor.tar.gz
 
 FROM scratch
-COPY --from=builder /goreplay .
-ENTRYPOINT ["./goreplay"]
+COPY --from=builder gor .
+ENTRYPOINT ["./gor"]


### PR DESCRIPTION
the Dockerfile is still using  gor v0.16.1. this PR bump it to v1.0.0