### PR TITLE
check parseURI error for elasticsearch init

### DIFF
--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -5,12 +5,13 @@ import (
 	"log"
 	"net/url"
 	"strings"
+
 	//"regexp"
 	"time"
 
 	"github.com/buger/goreplay/proto"
 
-	"github.com/mattbaird/elastigo/lib"
+	elastigo "github.com/mattbaird/elastigo/lib"
 )
 
 type ESUriErorr struct{}
@@ -67,6 +68,7 @@ func parseURI(URI string) (err error, index string) {
 
 	if parseErr != nil {
 		err = new(ESUriErorr)
+		return
 	}
 
 	//	check URL validity by extracting host and undex values.

--- a/elasticsearch.go
+++ b/elasticsearch.go
@@ -5,8 +5,6 @@ import (
 	"log"
 	"net/url"
 	"strings"
-
-	//"regexp"
 	"time"
 
 	"github.com/buger/goreplay/proto"


### PR DESCRIPTION
return error if it occurred when we parse elasticsearch url