### PR TITLE
WIP Make plugins not global. Revert last-chunk bytes to correct value

### DIFF
--- a/emitter_test.go
+++ b/emitter_test.go
@@ -17,10 +17,12 @@ func TestEmitter(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	for i := 0; i < 1000; i++ {
 		wg.Add(1)
@@ -43,12 +45,14 @@ func TestEmitterFiltered(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 	methods := HTTPMethods{[]byte("GET")}
 	Settings.modifierConfig = HTTPModifierConfig{methods: methods}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	wg.Add(2)
 
@@ -97,12 +101,14 @@ func TestEmitterRoundRobin(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output1, output2}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output1, output2},
+	}
 
 	Settings.splitOutput = true
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	for i := 0; i < 1000; i++ {
 		wg.Add(1)
@@ -130,10 +136,12 @@ func BenchmarkEmitter(b *testing.B) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	b.ResetTimer()
 

--- a/input_http_test.go
+++ b/input_http_test.go
@@ -21,10 +21,12 @@ func TestHTTPInput(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	address := strings.Replace(input.listener.Addr().String(), "[::]", "127.0.0.1", -1)
 
@@ -55,10 +57,12 @@ func TestInputHTTPLargePayload(t *testing.T) {
 		}
 		wg.Done()
 	})
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	wg.Add(1)
 	address := strings.Replace(input.listener.Addr().String(), "[::]", "127.0.0.1", -1)

--- a/input_raw_test.go
+++ b/input_raw_test.go
@@ -65,12 +65,14 @@ func TestRAWInputIPv4(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 
 	client := NewHTTPClient("http://"+listener.Addr().String(), &HTTPClientConfig{})
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	for i := 0; i < 100; i++ {
 		// request + response
@@ -113,12 +115,14 @@ func TestRAWInputNoKeepAlive(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 
 	client := NewHTTPClient("http://"+listener.Addr().String(), &HTTPClientConfig{})
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	for i := 0; i < 100; i++ {
 		// request + response
@@ -169,12 +173,14 @@ func TestRAWInputIPv6(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 
 	client := NewHTTPClient("http://"+listener.Addr().String(), &HTTPClientConfig{})
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	for i := 0; i < 100; i++ {
 		// request + response
@@ -234,10 +240,12 @@ func TestInputRAW100Expect(t *testing.T) {
 
 	httpOutput := NewHTTPOutput(replay.URL, &HTTPOutputConfig{})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{testOutput, httpOutput}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{testOutput, httpOutput},
+	}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	// Origin + Response/Request Test Output + Request Http Output
 	wg.Add(4)
@@ -284,10 +292,12 @@ func TestInputRAWChunkedEncoding(t *testing.T) {
 
 	httpOutput := NewHTTPOutput(replay.URL, &HTTPOutputConfig{Debug: true})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{httpOutput}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{httpOutput},
+	}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	wg.Add(2)
 
@@ -350,10 +360,12 @@ func TestInputRAWLargePayload(t *testing.T) {
 
 	httpOutput := NewHTTPOutput(replay.URL, &HTTPOutputConfig{Debug: false})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{httpOutput}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{httpOutput},
+	}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	wg.Add(2)
 	curl := exec.Command("curl", "http://"+originAddr, "--header", "Transfer-Encoding: chunked", "--header", "Expect:", "--data-binary", "@/tmp/large")
@@ -394,10 +406,12 @@ func BenchmarkRAWInput(b *testing.B) {
 
 	httpOutput := NewLimiter(NewHTTPOutput(upstreamAddr, &HTTPOutputConfig{}), "10%")
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output, httpOutput}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output, httpOutput},
+	}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	emitted := 0
 	fileContent, _ := ioutil.ReadFile("LICENSE.txt")

--- a/input_tcp_test.go
+++ b/input_tcp_test.go
@@ -27,10 +27,12 @@ func TestTCPInput(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	tcpAddr, err := net.ResolveTCPAddr("tcp", input.listener.Addr().String())
 
@@ -107,10 +109,12 @@ func TestTCPInputSecure(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	conf := &tls.Config{
 		InsecureSkipVerify: true,

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -18,10 +18,12 @@ func TestOutputLimiter(t *testing.T) {
 	}), "10")
 	wg.Add(10)
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	for i := 0; i < 100; i++ {
 		input.EmitGET()
@@ -42,10 +44,12 @@ func TestInputLimiter(t *testing.T) {
 	})
 	wg.Add(10)
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	for i := 0; i < 100; i++ {
 		input.(*Limiter).plugin.(*TestInput).EmitGET()
@@ -66,10 +70,12 @@ func TestPercentLimiter1(t *testing.T) {
 		wg.Done()
 	}), "0%")
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	for i := 0; i < 100; i++ {
 		input.EmitGET()
@@ -91,10 +97,12 @@ func TestPercentLimiter2(t *testing.T) {
 	}), "100%")
 	wg.Add(100)
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	for i := 0; i < 100; i++ {
 		input.EmitGET()

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -124,11 +124,13 @@ func TestEchoMiddleware(t *testing.T) {
 	// And redirect to another
 	output := NewHTTPOutput(to.URL, &HTTPOutputConfig{Debug: false})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 
 	// Start Gor
-	go Start(quit)
+	go Start(plugins, quit)
 
 	// Wait till middleware initialization
 	time.Sleep(100 * time.Millisecond)
@@ -186,11 +188,13 @@ func TestTokenMiddleware(t *testing.T) {
 	// And redirect to another
 	output := NewHTTPOutput(to.URL, &HTTPOutputConfig{Debug: true})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 
 	// Start Gor
-	go Start(quit)
+	go Start(plugins, quit)
 
 	// Wait for middleware to initialize
 	// Give go compiller time to build programm

--- a/output_file_test.go
+++ b/output_file_test.go
@@ -20,10 +20,12 @@ func TestFileOutput(t *testing.T) {
 	input := NewTestInput()
 	output := NewFileOutput("/tmp/test_requests.gor", &FileOutputConfig{flushInterval: time.Minute, append: true})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	for i := 0; i < 100; i++ {
 		wg.Add(2)
@@ -44,10 +46,12 @@ func TestFileOutput(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input2}
-	Plugins.Outputs = []io.Writer{output2}
+	plugins2 := &InOutPlugins{
+		Inputs:  []io.Reader{input2},
+		Outputs: []io.Writer{output2},
+	}
 
-	go Start(quit)
+	go Start(plugins2, quit)
 
 	wg.Wait()
 	close(quit)

--- a/output_http_test.go
+++ b/output_http_test.go
@@ -48,10 +48,12 @@ func TestHTTPOutput(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{http_output, output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{http_output, output},
+	}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	for i := 0; i < 1; i++ {
 		// 2 http-output, 2 - test output request, 2 - test output http response
@@ -88,10 +90,12 @@ func TestHTTPOutputKeepOriginalHost(t *testing.T) {
 
 	output := NewHTTPOutput(server.URL, &HTTPOutputConfig{Debug: false, OriginalHost: true})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	wg.Add(1)
 	input.EmitGET()
@@ -115,10 +119,12 @@ func TestOutputHTTPSSL(t *testing.T) {
 	input := NewTestInput()
 	output := NewHTTPOutput(server.URL, &HTTPOutputConfig{})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	wg.Add(2)
 
@@ -142,10 +148,12 @@ func BenchmarkHTTPOutput(b *testing.B) {
 	input := NewTestInput()
 	output := NewHTTPOutput(server.URL, &HTTPOutputConfig{})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	for i := 0; i < b.N; i++ {
 		wg.Add(1)

--- a/output_tcp_test.go
+++ b/output_tcp_test.go
@@ -19,10 +19,12 @@ func TestTCPOutput(t *testing.T) {
 	input := NewTestInput()
 	output := NewTCPOutput(listener.Addr().String(), &TCPOutputConfig{})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
@@ -71,10 +73,12 @@ func BenchmarkTCPOutput(b *testing.B) {
 	input := NewTestInput()
 	output := NewTCPOutput(listener.Addr().String(), &TCPOutputConfig{})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	plugins := &InOutPlugins{
+		Inputs:  []io.Reader{input},
+		Outputs: []io.Writer{output},
+	}
 
-	go Start(quit)
+	go Start(plugins, quit)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/plugins.go
+++ b/plugins.go
@@ -17,7 +17,7 @@ type InOutPlugins struct {
 var pluginMu sync.Mutex
 
 // Plugins holds all the plugin objects
-var Plugins *InOutPlugins = new(InOutPlugins)
+var plugins *InOutPlugins = new(InOutPlugins)
 
 // extractLimitOptions detects if plugin get called with limiter support
 // Returns address and limit
@@ -67,18 +67,18 @@ func registerPlugin(constructor interface{}, options ...interface{}) {
 
 	// Some of the output can be Readers as well because return responses
 	if isR && !isW {
-		Plugins.Inputs = append(Plugins.Inputs, pluginWrapper.(io.Reader))
+		plugins.Inputs = append(plugins.Inputs, pluginWrapper.(io.Reader))
 	}
 
 	if isW {
-		Plugins.Outputs = append(Plugins.Outputs, pluginWrapper.(io.Writer))
+		plugins.Outputs = append(plugins.Outputs, pluginWrapper.(io.Writer))
 	}
 
-	Plugins.All = append(Plugins.All, plugin)
+	plugins.All = append(plugins.All, plugin)
 }
 
 // InitPlugins specify and initialize all available plugins
-func InitPlugins() {
+func InitPlugins() *InOutPlugins {
 	pluginMu.Lock()
 	defer pluginMu.Unlock()
 
@@ -149,4 +149,6 @@ func InitPlugins() {
 	if Settings.inputKafkaConfig.host != "" && Settings.inputKafkaConfig.topic != "" {
 		registerPlugin(NewKafkaInput, "", &Settings.inputKafkaConfig)
 	}
+
+	return plugins
 }

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -1,42 +1,38 @@
 package main
 
 import (
-	"io"
 	"testing"
 )
 
 func TestPluginsRegistration(t *testing.T) {
-	Plugins.Inputs = []io.Reader{}
-	Plugins.Outputs = []io.Writer{}
-
 	Settings.inputDummy = MultiOption{"[]"}
 	Settings.outputDummy = MultiOption{"[]"}
 	Settings.outputHTTP = MultiOption{"www.example.com|10"}
 	Settings.inputFile = MultiOption{"/dev/null"}
 
-	InitPlugins()
+	plugins := InitPlugins()
 
-	if len(Plugins.Inputs) != 2 {
-		t.Errorf("Should be 2 inputs %d", len(Plugins.Inputs))
+	if len(plugins.Inputs) != 2 {
+		t.Errorf("Should be 2 inputs %d", len(plugins.Inputs))
 	}
 
-	if _, ok := Plugins.Inputs[0].(*DummyInput); !ok {
+	if _, ok := plugins.Inputs[0].(*DummyInput); !ok {
 		t.Errorf("First input should be DummyInput")
 	}
 
-	if _, ok := Plugins.Inputs[1].(*FileInput); !ok {
+	if _, ok := plugins.Inputs[1].(*FileInput); !ok {
 		t.Errorf("Second input should be FileInput")
 	}
 
-	if len(Plugins.Outputs) != 2 {
-		t.Errorf("Should be 2 output %d", len(Plugins.Outputs))
+	if len(plugins.Outputs) != 2 {
+		t.Errorf("Should be 2 output %d", len(plugins.Outputs))
 	}
 
-	if _, ok := Plugins.Outputs[0].(*DummyOutput); !ok {
+	if _, ok := plugins.Outputs[0].(*DummyOutput); !ok {
 		t.Errorf("First output should be DummyOutput")
 	}
 
-	if l, ok := Plugins.Outputs[1].(*Limiter); ok {
+	if l, ok := plugins.Outputs[1].(*Limiter); ok {
 		if _, ok := l.plugin.(*HTTPOutput); !ok {
 			t.Errorf("HTTPOutput should be wrapped in limiter")
 		}

--- a/raw_socket_listener/tcp_message.go
+++ b/raw_socket_listener/tcp_message.go
@@ -199,7 +199,9 @@ func (t *TCPMessage) checkSeqIntegrity() {
 
 var bEmptyLine = []byte("\r\n\r\n")
 var bBR = []byte("\r\n")
-var bChunkEnd = []byte("\r\n0\r\n\r\n")
+
+// last-chunk always is 0\r\n\r\n\. More info https://tools.ietf.org/html/rfc2616#section-3.6.1
+var bChunkEnd = []byte("0\r\n\r\n")
 
 func (t *TCPMessage) updateHeadersPacket() {
 	if len(t.packets) == 1 {


### PR DESCRIPTION
Make Plugins variable not global to fix concurrency in test
Revert last-chunk in chunked transfer coding to correct value (https://tools.ietf.org/html/rfc2616#section-3.6.1) fyi @bruce34 