### PR TITLE
Fix race input_file.go while closing the file and remove dead code.

### DIFF
--- a/input_file.go
+++ b/input_file.go
@@ -21,7 +21,7 @@ type fileInputReader struct {
 	data      []byte
 	file      *os.File
 	timestamp int64
-	closed int32 // Value of 0 indicates open.
+	closed    int32 // Value of 0 indicates that the file is still open.
 }
 
 func (f *fileInputReader) parseNext() error {
@@ -65,8 +65,7 @@ func (f *fileInputReader) ReadPayload() []byte {
 	return f.data
 }
 func (f *fileInputReader) Close() error {
-	closed := atomic.LoadInt32(&f.closed)
-	if closed == 0 {
+	if atomic.LoadInt32(&f.closed) == 0 {
 		atomic.StoreInt32(&f.closed, 1)
 		f.file.Close()
 	}

--- a/input_file.go
+++ b/input_file.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -20,6 +21,7 @@ type fileInputReader struct {
 	data      []byte
 	file      *os.File
 	timestamp int64
+	closed int32 // Value of 0 indicates open.
 }
 
 func (f *fileInputReader) parseNext() error {
@@ -36,8 +38,7 @@ func (f *fileInputReader) parseNext() error {
 			}
 
 			if err == io.EOF {
-				f.file.Close()
-				f.file = nil
+				f.Close()
 				return err
 			}
 		}
@@ -64,7 +65,9 @@ func (f *fileInputReader) ReadPayload() []byte {
 	return f.data
 }
 func (f *fileInputReader) Close() error {
-	if f.file != nil {
+	closed := atomic.LoadInt32(&f.closed)
+	if closed == 0 {
+		atomic.StoreInt32(&f.closed, 1)
 		f.file.Close()
 	}
 
@@ -79,7 +82,7 @@ func NewFileInputReader(path string) *fileInputReader {
 		return nil
 	}
 
-	r := &fileInputReader{file: file}
+	r := &fileInputReader{file: file, closed: 0}
 	if strings.HasSuffix(path, ".gz") {
 		gzReader, err := gzip.NewReader(file)
 		if err != nil {
@@ -125,12 +128,6 @@ func NewFileInput(path string, loop bool) (i *FileInput) {
 	return
 }
 
-type NextFileNotFound struct{}
-
-func (_ *NextFileNotFound) Error() string {
-	return "There is no new files"
-}
-
 func (i *FileInput) init() (err error) {
 	defer i.mu.Unlock()
 	i.mu.Lock()
@@ -170,7 +167,7 @@ func (i *FileInput) String() string {
 // Find reader with smallest timestamp e.g next payload in row
 func (i *FileInput) nextReader() (next *fileInputReader) {
 	for _, r := range i.readers {
-		if r == nil || r.file == nil {
+		if r == nil || atomic.LoadInt32(&r.closed) != 0 {
 			continue
 		}
 


### PR DESCRIPTION
Currently, there is a race condition to close the input file in `input_file.go`, since fileInputReader.file  is accessed by multiple go routine concurrently. This PR fixed the race when closing the input file by allowing the first caller to close and succeeding caller would be a no-op.