### PR TITLE
Settings parse and some typo fixes

### DIFF
--- a/emitter_test.go
+++ b/emitter_test.go
@@ -22,7 +22,6 @@ func TestEmitter(t *testing.T) {
 		Outputs: []io.Writer{output},
 	}
 
-	checkSettings()
 	go Start(plugins, quit)
 
 	for i := 0; i < 1000; i++ {

--- a/emitter_test.go
+++ b/emitter_test.go
@@ -22,6 +22,7 @@ func TestEmitter(t *testing.T) {
 		Outputs: []io.Writer{output},
 	}
 
+	checkSettings()
 	go Start(plugins, quit)
 
 	for i := 0; i < 1000; i++ {

--- a/gor.go
+++ b/gor.go
@@ -62,6 +62,7 @@ func main() {
 		log.Fatal(http.ListenAndServe(args[1], loggingMiddleware(http.FileServer(http.Dir(dir)))))
 	} else {
 		flag.Parse()
+		checkSettings()
 		plugins = InitPlugins()
 	}
 

--- a/output_file.go
+++ b/output_file.go
@@ -281,7 +281,6 @@ func (o *FileOutput) Close() error {
 	o.Lock()
 	defer o.Unlock()
 	return o.closeLocked()
-	return nil
 }
 
 // IsClosed returns if the output file is closed or not.

--- a/plugins.go
+++ b/plugins.go
@@ -106,7 +106,7 @@ func InitPlugins() *InOutPlugins {
 	}
 
 	for _, options := range Settings.inputRAW {
-		registerPlugin(NewRAWInput, options, engine, Settings.inputRAWTrackResponse, Settings.inputRAWExpire, Settings.inputRAWRealIPHeader, Settings.inputRAWBpfFilter, Settings.inputRAWTimestampType, Settings.inputRawBufferSize)
+		registerPlugin(NewRAWInput, options, engine, Settings.inputRAWTrackResponse, Settings.inputRAWExpire, Settings.inputRAWRealIPHeader, Settings.inputRAWBpfFilter, Settings.inputRAWTimestampType, Settings.inputRAWBufferSize)
 	}
 
 	for _, options := range Settings.inputTCP {

--- a/raw_socket_listener/listener.go
+++ b/raw_socket_listener/listener.go
@@ -372,7 +372,7 @@ func (t *Listener) readPcap() {
 
 			handle, herr := inactive.Activate()
 			if herr != nil {
-				log.Println("PCAP Activate error:", herr)
+				log.Printf("PCAP Activate device '%s' error: %s\n", device.Name, herr)
 				wg.Done()
 				return
 			}

--- a/raw_socket_listener/listener_test.go
+++ b/raw_socket_listener/listener_test.go
@@ -262,7 +262,7 @@ func TestRawListenerResponse(t *testing.T) {
 	select {
 	case req = <-listener.messagesChan:
 	case <-time.After(time.Millisecond):
-		t.Error("Should return respose immediately")
+		t.Error("Should return request immediately")
 		return
 	}
 
@@ -598,7 +598,7 @@ func TestResponseZeroContentLength(t *testing.T) {
 	select {
 	case req = <-listener.messagesChan:
 	case <-time.After(time.Millisecond):
-		t.Error("Should return respose immediately")
+		t.Error("Should return request immediately")
 		return
 	}
 

--- a/settings.go
+++ b/settings.go
@@ -211,6 +211,12 @@ func init() {
 	flag.Var(&Settings.modifierConfig.headerHashFilters, "output-http-header-hash-filter", "WARNING: `output-http-header-hash-filter` DEPRECATED, use `--http-header-hash-limiter` instead")
 
 	flag.Var(&Settings.modifierConfig.paramHashFilters, "http-param-limiter", "Takes a fraction of requests, consistently taking or rejecting a request based on the FNV32-1A hash of a specific GET param:\n\t gor --input-raw :8080 --output-http staging.com --http-param-limiter user_id:25%")
+
+	// default values, using for tests
+	Settings.outputFileConfig.sizeLimit = 33554432
+	Settings.outputFileConfig.outputFileMaxSize = 1099511627776
+	Settings.copyBufferSize = 5242880
+	Settings.inputRAWBufferSize = 0
 }
 
 func checkSettings() {


### PR DESCRIPTION
We should check and validate flag values after `flag.Parse()` cause now it always has default values.
@urbanishimwe please test it on your pc

- fix some typos in tests (`reponse` -> `request`)
- add more information to log string:
before: `PCAP Activate error: Cannot set as promisc`
after: `PCAP Activate device 'llw0' error: Cannot set as promisc`