### PR TITLE
make raw socket usable and minor optimization.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,8 @@ bench:
 	$(RUN) go test $(LDFLAGS) -v -run NOT_EXISTING -bench $(BENCHMARK) -benchtime 5s
 
 profile_test:
-	$(RUN) go test $(LDFLAGS) -run $(TEST) ./raw_socket_listener/. $(ARGS) -memprofile mem.mprof -cpuprofile cpu.out
-	$(RUN) go test $(LDFLAGS) -run $(TEST) ./raw_socket_listener/. $(ARGS) -c
+	$(RUN) go test $(LDFLAGS) -run $(TEST) ./capture/. $(ARGS) -memprofile mem.mprof -cpuprofile cpu.out
+	$(RUN) go test $(LDFLAGS) -run $(TEST) ./capture/. $(ARGS) -c
 
 # Used mainly for debugging, because docker container do not have access to parent machine ports
 run:

--- a/capture/listener_test.go
+++ b/capture/listener_test.go
@@ -12,7 +12,7 @@ import (
 func TestRawListenerInput(t *testing.T) {
 	var req, resp *TCPMessage
 
-	listener := NewListener("", "0", EnginePcapFile, true, 10*time.Millisecond, "", "", 0, false, false)
+	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0, false, false)
 	defer listener.Close()
 
 	reqPacket := buildPacket(true, 1, 1, []byte("GET / HTTP/1.1\r\n\r\n"), time.Now())

--- a/capture/listener_test.go
+++ b/capture/listener_test.go
@@ -431,10 +431,6 @@ func testChunkedSequence(t *testing.T, listener *Listener, packets ...*TCPPacket
 	if len(listener.respAliases) != 0 {
 		t.Fatal("respAliases non empty:", listener.respAliases)
 	}
-
-	if len(listener.respWithoutReq) != 0 {
-		t.Fatal("respWithoutReq non empty:", listener.respWithoutReq)
-	}
 }
 
 // permutation using heap algorithm https://en.wikipedia.org/wiki/Heap%27s_algorithm

--- a/capture/listener_test.go
+++ b/capture/listener_test.go
@@ -1,4 +1,4 @@
-package rawSocket
+package capture
 
 import (
 	"bytes"
@@ -12,7 +12,7 @@ import (
 func TestRawListenerInput(t *testing.T) {
 	var req, resp *TCPMessage
 
-	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0, false, false)
+	listener := NewListener("", "0", EnginePcapFile, true, 10*time.Millisecond, "", "", 0, false, false)
 	defer listener.Close()
 
 	reqPacket := buildPacket(true, 1, 1, []byte("GET / HTTP/1.1\r\n\r\n"), time.Now())
@@ -420,14 +420,6 @@ func testChunkedSequence(t *testing.T, listener *Listener, packets ...*TCPPacket
 		t.Fatal("packetsChan non empty:", listener.packetsChan)
 	}
 
-	if len(listener.messagesChan) != 0 {
-		t.Fatal("messagesChan non empty:", <-listener.messagesChan)
-	}
-
-	if len(listener.messages) != 0 {
-		t.Fatal("Messages non empty:", listener.messages)
-	}
-
 	if len(listener.ackAliases) != 0 {
 		t.Fatal("ackAliases non empty:", listener.ackAliases)
 	}
@@ -445,24 +437,32 @@ func testChunkedSequence(t *testing.T, listener *Listener, packets ...*TCPPacket
 	}
 }
 
-func permutation(n int, list []*TCPPacket) []*TCPPacket {
-	if len(list) == 1 {
-		return list
+// permutation using heap algorithm https://en.wikipedia.org/wiki/Heap%27s_algorithm
+func permutation(a []*TCPPacket, f func([]*TCPPacket)) {
+	n := len(a)
+	c := make([]int, n)
+	f(a)
+	i := 0
+	for i < n {
+		if c[i] < i {
+			if i&1 != 1 {
+				a[0], a[i] = a[i], a[0]
+			} else {
+				a[c[i]], a[i] = a[i], a[c[i]]
+			}
+			f(a)
+			c[i]++
+			i = 0
+		} else {
+			c[i] = 0
+			i++
+		}
 	}
-
-	k := n % len(list)
-
-	first := []*TCPPacket{list[k]}
-	next := make([]*TCPPacket, len(list)-1)
-
-	copy(next, append(list[:k], list[k+1:]...))
-
-	return append(first, permutation(n/len(list), next)...)
 }
 
 // Response comes before Request
 func TestRawListenerChunkedWrongOrder(t *testing.T) {
-	listener := NewListener("", "0", EnginePcap, true, 10*time.Millisecond, "", "", 0, false, false)
+	listener := NewListener("", "0", EnginePcap, true, 10*time.Second, "", "", 0, false, false)
 	defer listener.Close()
 
 	reqPacket1 := firstPacket([]byte("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\nExpect: 100-continue\r\n\r\n"))
@@ -474,12 +474,11 @@ func TestRawListenerChunkedWrongOrder(t *testing.T) {
 
 	respPacket2 := responsePacket(reqPacket4, []byte("HTTP/1.1 200 OK\r\n\r\n"))
 
-	// Should re-construct message from all possible combinations
-	for i := 0; i < 6*5*4*3*2*1; i++ {
-		packets := permutation(i, []*TCPPacket{reqPacket1, reqPacket2, reqPacket3, reqPacket4, respPacket1, respPacket2})
-
-		testChunkedSequence(t, listener, packets...)
+	f := func(p []*TCPPacket) {
+		testChunkedSequence(t, listener, p...)
 	}
+	// Should re-construct message from all possible combinations
+	permutation([]*TCPPacket{reqPacket1, reqPacket2, reqPacket3, reqPacket4, respPacket1, respPacket2}, f)
 }
 
 func chunkedPostMessage() []*TCPPacket {

--- a/capture/tcp_message.go
+++ b/capture/tcp_message.go
@@ -1,11 +1,10 @@
-package rawSocket
+package capture
 
 import (
 	"bytes"
 	"crypto/sha1"
 	"encoding/binary"
 	"encoding/hex"
-	"log"
 	"net"
 	"strconv"
 	"strings"
@@ -13,8 +12,6 @@ import (
 
 	"github.com/buger/goreplay/proto"
 )
-
-var _ = log.Println
 
 // TCPMessage ensure that all TCP packets for given request is received, and processed in right sequence
 // Its needed because all TCP message can be fragmented or re-transmitted

--- a/capture/tcp_message_test.go
+++ b/capture/tcp_message_test.go
@@ -1,4 +1,4 @@
-package rawSocket
+package capture
 
 import (
 	"bytes"

--- a/capture/tcp_packet.go
+++ b/capture/tcp_packet.go
@@ -1,14 +1,11 @@
-package rawSocket
+package capture
 
 import (
 	"encoding/binary"
-	"log"
 	"strconv"
 	"strings"
 	"time"
 )
-
-var _ = log.Println
 
 // TCP Flags
 const (
@@ -102,7 +99,6 @@ func (t *TCPPacket) dump() *packet {
 	}
 
 	copy(packetData[16:], t.Data)
-
 	return &packet{
 		srcIP:     packetSrcIP,
 		data:      packetData,

--- a/input_raw.go
+++ b/input_raw.go
@@ -5,8 +5,8 @@ import (
 	"net"
 	"time"
 
+	raw "github.com/buger/goreplay/capture"
 	"github.com/buger/goreplay/proto"
-	raw "github.com/buger/goreplay/raw_socket_listener"
 )
 
 // RAWInput used for intercepting traffic for given address
@@ -44,9 +44,7 @@ func NewRAWInput(address string, engine int, trackResponse bool, expire time.Dur
 	i.trackResponse = trackResponse
 	i.timestampType = timestampType
 	i.bufferSize = bufferSize
-
 	i.listen(address)
-	i.listener.IsReady()
 
 	return
 }
@@ -76,7 +74,6 @@ func (i *RAWInput) listen(address string) {
 	Debug("Listening for traffic on: " + address)
 
 	host, port, err := net.SplitHostPort(address)
-
 	if err != nil {
 		log.Fatalf("input-raw: error while parsing address: %s", err)
 	}
@@ -90,13 +87,8 @@ func (i *RAWInput) listen(address string) {
 			select {
 			case <-i.quit:
 				return
-			default:
+			case i.data <- <-ch: // Receiving TCPMessage object
 			}
-
-			// Receiving TCPMessage object
-			m := <-ch
-
-			i.data <- m
 		}
 	}()
 }


### PR DESCRIPTION
**ListenPacket** can be used to listen to traffics from networks that are not **multicast**. it takes less time and fewer resources to spin up **raw socket** more than **pcap**.
The implementations applied is to create an active routine that continuously read packet as they come.
For requests of the large body, one may increase the buffer size. the default/minimum buffer size is 64kb(this is because of the MTU of most non-multicast IP is 64kb).

These changes were tested using **postman**

### need help
- it doesn't work with `curl, browser....`