### PR TITLE
Reduce allocation and unnecessary layers

### DIFF
--- a/byteutils/byteutils.go
+++ b/byteutils/byteutils.go
@@ -2,7 +2,6 @@
 package byteutils
 
 import (
-	"reflect"
 	"unsafe"
 )
 
@@ -48,9 +47,6 @@ func Replace(a []byte, from, to int, new []byte) []byte {
 }
 
 // SliceToString preferred for large body payload (zero allocation and faster)
-func SliceToString(buf *[]byte, s *string) {
-	bHeader := (*reflect.SliceHeader)(unsafe.Pointer(buf))
-	sHeader := (*reflect.StringHeader)(unsafe.Pointer(s))
-	sHeader.Data = bHeader.Data
-	sHeader.Len = bHeader.Len
+func SliceToString(buf []byte) string {
+	return *(*string)(unsafe.Pointer(&buf))
 }

--- a/byteutils/byteutils_test.go
+++ b/byteutils/byteutils_test.go
@@ -32,9 +32,10 @@ func TestReplace(t *testing.T) {
 }
 
 func BenchmarkStringtoSlice(b *testing.B) {
-	b.StopTimer()
-	buf := make([]byte, b.N)
-	b.StartTimer()
-	s := new(string)
-	SliceToString(&buf, s)
+	var s string
+	var buf [1 << 20]byte
+	for i := 0; i < b.N; i++ {
+		s = SliceToString(buf[:])
+	}
+	_ = s // avoid gc to optimize away the loop body
 }

--- a/output_dummy.go
+++ b/output_dummy.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"os"
 )
 
 // DummyOutput used for debugging, prints all incoming requests
@@ -16,9 +16,7 @@ func NewDummyOutput() (di *DummyOutput) {
 }
 
 func (i *DummyOutput) Write(data []byte) (int, error) {
-	fmt.Println(string(data))
-
-	return len(data), nil
+	return os.Stdout.Write(data)
 }
 
 func (i *DummyOutput) String() string {

--- a/output_dummy.go
+++ b/output_dummy.go
@@ -16,7 +16,9 @@ func NewDummyOutput() (di *DummyOutput) {
 }
 
 func (i *DummyOutput) Write(data []byte) (int, error) {
-	return os.Stdout.Write(data)
+	n, err := os.Stdout.Write(data)
+	os.Stdout.Write([]byte{'\n'})
+	return n, err
 }
 
 func (i *DummyOutput) String() string {

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -332,8 +332,7 @@ const (
 
 // HasResponseTitle reports whether this payload has an HTTP/1 response title
 func HasResponseTitle(payload []byte) bool {
-	var s string
-	byteutils.SliceToString(&payload, &s)
+	s := byteutils.SliceToString(payload)
 	if len(s) < MinResponseCount {
 		return false
 	}
@@ -361,8 +360,7 @@ func HasResponseTitle(payload []byte) bool {
 
 // HasRequestTitle reports whether this payload has an HTTP/1 request title
 func HasRequestTitle(payload []byte) bool {
-	var s string
-	byteutils.SliceToString(&payload, &s)
+	s := byteutils.SliceToString(payload)
 	if len(s) < MinRequestCount {
 		return false
 	}

--- a/proto/proto_test.go
+++ b/proto/proto_test.go
@@ -456,9 +456,6 @@ func TestHasFullPayload(t *testing.T) {
 }
 
 func BenchmarkHasFullPayload(b *testing.B) {
-	var payload [32]byte
-	payload[30] = '\r'
-	payload[31] = '\n'
 	var buf bytes.Buffer
 	buf.Write([]byte("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n"))
 	var chunk = []byte("1e\r\n111111111111111111111111111111\r\n")

--- a/proto/proto_test.go
+++ b/proto/proto_test.go
@@ -2,10 +2,8 @@ package proto
 
 import (
 	"bytes"
-	"fmt"
 	"reflect"
 	"testing"
-	"time"
 )
 
 func TestHeader(t *testing.T) {
@@ -458,28 +456,24 @@ func TestHasFullPayload(t *testing.T) {
 }
 
 func BenchmarkHasFullPayload(b *testing.B) {
-	now := time.Now()
-	payload := make([]byte, 0xfc00)
-	for i := 0; i < 0xfc00; i++ {
-		payload[i] = '1'
+	var payload [32]byte
+	payload[30] = '\r'
+	payload[31] = '\n'
+	var buf bytes.Buffer
+	buf.Write([]byte("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n"))
+	var chunk = []byte("1e\r\n111111111111111111111111111111\r\n")
+	for i := 0; i < 5000; i++ {
+		buf.Write(chunk)
 	}
+	buf.Write([]byte("0\r\n\r\n"))
+	data := buf.Bytes()
 	var ok bool
-	data := []byte("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n")
-	if ok = HasFullPayload(data); ok {
-		b.Error("HasFullPayload should fail")
-		return
-	}
+	b.ResetTimer() // ignores the upper initialization
+	b.ReportMetric(float64(5000), "chunks/op")
 	for i := 0; i < b.N; i++ {
-		data = append(data, []byte(fmt.Sprintf("fc00\r\n%s\r\n", payload))...)
-		if ok = HasFullPayload(data); ok {
-			b.Error("HasFullPayload should fail")
-			return
-		}
+		ok = HasFullPayload(data)
 	}
-	data = append(data, []byte("0\r\n\r\n")...)
-	if ok = HasFullPayload(data); !ok {
-		b.Error("HasFullPayload should pass")
-		return
+	if !ok {
+		b.Fail()
 	}
-	b.Logf("%dKB chunks in %s", b.N*64, time.Since(now))
 }

--- a/tcp/tcp_packet.go
+++ b/tcp/tcp_packet.go
@@ -21,8 +21,11 @@ type Packet struct {
 	gopacket.LinkLayer
 
 	// IP Header
-	gopacket.NetworkLayer
 	Version uint8 // Ip version
+	SrcIP   net.IP
+	DstIP   net.IP
+	IHL     uint8
+	Length  uint16
 
 	// TCP Segment Header
 	*layers.TCP
@@ -35,10 +38,12 @@ type Packet struct {
 // ParsePacket parse raw packets
 func ParsePacket(packet gopacket.Packet) (pckt *Packet, err error) {
 	// early check of error
+	if packet == nil {
+		return
+	}
 	defer func() {
 		if packet.ErrorLayer() != nil {
 			err = packet.ErrorLayer().Error()
-			println(err.Error())
 			return
 		}
 	}()
@@ -55,11 +60,17 @@ func ParsePacket(packet gopacket.Packet) (pckt *Packet, err error) {
 
 	// parsing network layer
 	if net4, ok := packet.NetworkLayer().(*layers.IPv4); ok {
-		pckt.NetworkLayer = net4
 		pckt.Version = 4
+		pckt.SrcIP = net4.SrcIP
+		pckt.DstIP = net4.DstIP
+		pckt.IHL = net4.IHL * 4
+		pckt.Length = net4.Length
 	} else if net6, ok := packet.NetworkLayer().(*layers.IPv6); ok {
-		pckt.NetworkLayer = net6
 		pckt.Version = 6
+		pckt.SrcIP = net6.SrcIP
+		pckt.DstIP = net6.DstIP
+		pckt.IHL = 40
+		pckt.Length = net6.Length
 	} else {
 		pckt = nil
 		return
@@ -75,56 +86,23 @@ func ParsePacket(packet gopacket.Packet) (pckt *Packet, err error) {
 	pckt.DataOffset *= 4
 
 	// calculating lost data
-	headerSize := int(uint32(pckt.DataOffset) + uint32(pckt.IHL()))
+	headerSize := int(uint32(pckt.DataOffset) + uint32(pckt.IHL))
 	if pckt.Version == 6 {
 		headerSize -= 40 // in ipv6 the length of payload doesn't include the IPheader size
 	}
-	pckt.Lost = pckt.Length() - uint16(headerSize+len(pckt.Payload))
+	pckt.Lost = pckt.Length - uint16(headerSize+len(pckt.Payload))
 
 	return
 }
 
 // Src returns the source socket of a packet
 func (pckt *Packet) Src() string {
-	return fmt.Sprintf("%s:%d", pckt.SrcIP(), pckt.SrcPort)
+	return fmt.Sprintf("%s:%d", pckt.SrcIP, pckt.SrcPort)
 }
 
 // Dst returns destination socket
 func (pckt *Packet) Dst() string {
-	return fmt.Sprintf("%s:%d", pckt.DstIP(), pckt.DstPort)
-}
-
-// SrcIP returns source IP address
-func (pckt *Packet) SrcIP() net.IP {
-	if pckt.Version == 4 {
-		return pckt.NetworkLayer.(*layers.IPv4).SrcIP
-	}
-	return pckt.NetworkLayer.(*layers.IPv6).SrcIP
-}
-
-// DstIP returns destination IP address
-func (pckt *Packet) DstIP() net.IP {
-	if pckt.Version == 4 {
-		return pckt.NetworkLayer.(*layers.IPv4).DstIP
-	}
-	return pckt.NetworkLayer.(*layers.IPv6).DstIP
-}
-
-// IHL returns IP header length in bytes
-func (pckt *Packet) IHL() uint8 {
-	if l, ok := pckt.NetworkLayer.(*layers.IPv4); ok {
-		return l.IHL * 4
-	}
-	// on IPV6 it's constant, https://en.wikipedia.org/wiki/IPv6_packet#Fixed_header
-	return 40
-}
-
-// Length returns the total length of the packet(IP header, TCP header and the actual data)
-func (pckt *Packet) Length() uint16 {
-	if l, ok := pckt.NetworkLayer.(*layers.IPv4); ok {
-		return l.Length
-	}
-	return pckt.NetworkLayer.(*layers.IPv6).Length
+	return fmt.Sprintf("%s:%d", pckt.DstIP, pckt.DstPort)
 }
 
 // SYNOptions returns MSS and windowscale of syn packets
@@ -205,8 +183,8 @@ Lost Data: %d`,
 		pckt.LinkInfo(),
 		pckt.Src(),
 		pckt.Dst(),
-		pckt.IHL(),
-		pckt.Length(),
+		pckt.IHL,
+		pckt.Length,
 		pckt.Seq,
 		pckt.Ack,
 		pckt.DataOffset,


### PR DESCRIPTION
The focus here was to **reduce allocation in TCP parser** but speed may have hopeful improved too!
pool no longer use map's key of **string** it uses **uint64**
**Benchmarks** was revamped to be more clear
if you want to compare these results copy the benchmark in tcp/bench_test.go@reduce-allocation to tcp/bench_test.go@master:

**before(master)**:
```
BenchmarkPacketParseAndSort-4         	 1000000	      1006 ns/op	      64 B/op	       2 allocs/op
BenchmarkMessageParserWithoutHint-4   	     625	   1772309 ns/op	      1000 packets/op	  419096 B/op	   10045 allocs/op
BenchmarkMessageParserWithHint-4      	      74	  14969926 ns/op	      1000 chunks/op	      1002 packets/op	  450992 B/op	   10126 allocs/op
```

**After(this branch)**:
```
BenchmarkPacketParseAndSort-4         	 1267662	       941 ns/op	      64 B/op	       2 allocs/op
BenchmarkMessageParserWithoutHint-4   	    2256	    523474 ns/op	      1000 packets/op	  243530 B/op	    1037 allocs/op
BenchmarkMessageParserWithHint-4      	      80	  13990955 ns/op	      1000 chunks/op	      1002 packets/op	  268609 B/op	    1099 allocs/op

```