### PR TITLE
Use int64 for Size

### DIFF
--- a/size/size.go
+++ b/size/size.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Size represents size that implements flag.Var
-type Size int
+type Size int64
 
 // the following regexes follow Go semantics https://golang.org/ref/spec#Letters_and_digits
 var (


### PR DESCRIPTION
Use int64 for Size to avoid compile failure on 32bit platforms:

`./settings.go:224:46: constant 1099511627776 overflows size.Size`

due to:

`	Settings.OutputFileConfig.OutputFileMaxSize = 1099511627776`