### PR TITLE
Fix #838 : Kafka in TLS (not only mutual TLS)

### DIFF
--- a/kafka.go
+++ b/kafka.go
@@ -64,7 +64,7 @@ func NewTLSConfig(clientCertFile, clientKeyFile, caCertFile string) (*tls.Config
 		return &tlsConfig, ErrorTLSMissingKey
 	}
 	if clientCertFile == "" && clientKeyFile != "" {
-		return &tlsConfig, ErrorTLSMissingCert
+		return &tlsConfig, errors.New("missing TLS client certificate in kafka")
 	}
 	// Load client cert
 	if  (clientCertFile != "") && (clientKeyFile != "") {

--- a/kafka.go
+++ b/kafka.go
@@ -57,7 +57,7 @@ func NewTLSConfig(clientCertFile, clientKeyFile, caCertFile string) (*tls.Config
 	tlsConfig := tls.Config{}
 
 	if clientCertFile != "" && clientKeyFile == "" {
-		return &tlsConfig, errors.New(mMissing key of client certificate in kafka")
+		return &tlsConfig, errors.New("Missing key of client certificate in kafka")
 	}
 	if clientCertFile == "" && clientKeyFile != "" {
 		return &tlsConfig, errors.New("missing TLS client certificate in kafka")

--- a/kafka.go
+++ b/kafka.go
@@ -61,7 +61,7 @@ func NewTLSConfig(clientCertFile, clientKeyFile, caCertFile string) (*tls.Config
 	tlsConfig := tls.Config{}
 
 	if clientCertFile != "" && clientKeyFile == "" {
-		return &tlsConfig, ErrorTLSMissingKey
+		return &tlsConfig, errors.New(mMissing key of client certificate in kafka")
 	}
 	if clientCertFile == "" && clientKeyFile != "" {
 		return &tlsConfig, errors.New("missing TLS client certificate in kafka")

--- a/kafka.go
+++ b/kafka.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -50,34 +51,47 @@ type KafkaMessage struct {
 	ReqHeaders map[string]string `json:"Req_Headers,omitempty"`
 }
 
+// ErrorTLSMissingKey is the error when client cert is present but key is missing
+var ErrorTLSMissingKey = errors.New("Missing key of client certificate")
+// ErrorTLSMissingCert is the error when key is present but client cert is missing
+var ErrorTLSMissingCert = errors.New("Missing client certificate")
+
 // NewTLSConfig loads TLS certificates
 func NewTLSConfig(clientCertFile, clientKeyFile, caCertFile string) (*tls.Config, error) {
 	tlsConfig := tls.Config{}
 
+	if clientCertFile != "" && clientKeyFile == "" {
+		return &tlsConfig, ErrorTLSMissingKey
+	}
+	if clientCertFile == "" && clientKeyFile != "" {
+		return &tlsConfig, ErrorTLSMissingCert
+	}
 	// Load client cert
-	cert, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
-	if err != nil {
-		return &tlsConfig, err
+	if  (clientCertFile != "") && (clientKeyFile != "") {
+		cert, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
+		if err != nil {
+			return &tlsConfig, err
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
 	}
-	tlsConfig.Certificates = []tls.Certificate{cert}
-
 	// Load CA cert
-	caCert, err := ioutil.ReadFile(caCertFile)
-	if err != nil {
-		return &tlsConfig, err
+	if caCertFile != "" {
+		caCert, err := ioutil.ReadFile(caCertFile)
+		if err != nil {
+			return &tlsConfig, err
+		}
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+		tlsConfig.RootCAs = caCertPool
 	}
-	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(caCert)
-	tlsConfig.RootCAs = caCertPool
-
-	return &tlsConfig, err
+	return &tlsConfig, nil
 }
 
 // NewKafkaConfig returns Kafka config with or without TLS
 func NewKafkaConfig(tlsConfig *KafkaTLSConfig) *sarama.Config {
 	config := sarama.NewConfig()
 	// Configuration options go here
-	if (tlsConfig != nil) && (tlsConfig.CACert != "") && (tlsConfig.ClientCert != "") && (tlsConfig.ClientKey != "") {
+	if tlsConfig != nil && (tlsConfig.ClientCert != "" || tlsConfig.CACert != "") {
 		config.Net.TLS.Enable = true
 		tlsConfig, err := NewTLSConfig(tlsConfig.ClientCert, tlsConfig.ClientKey, tlsConfig.CACert)
 		if err != nil {

--- a/kafka.go
+++ b/kafka.go
@@ -51,10 +51,6 @@ type KafkaMessage struct {
 	ReqHeaders map[string]string `json:"Req_Headers,omitempty"`
 }
 
-// ErrorTLSMissingKey is the error when client cert is present but key is missing
-var ErrorTLSMissingKey = errors.New("Missing key of client certificate")
-// ErrorTLSMissingCert is the error when key is present but client cert is missing
-var ErrorTLSMissingCert = errors.New("Missing client certificate")
 
 // NewTLSConfig loads TLS certificates
 func NewTLSConfig(clientCertFile, clientKeyFile, caCertFile string) (*tls.Config, error) {


### PR DESCRIPTION
Allowing to connect to a TLS Kafka (only server certificate, no client cert) : 
1.  allow --kafka-tls-ca-cert without --kafka-tls-client-cert and --kafka-tls-client-key
1. and error messages when missing client-cert or client-key for Mutual TLS

