### PR TITLE
Update output_http.go (fix #862)

### DIFF
--- a/output_http.go
+++ b/output_http.go
@@ -300,9 +300,11 @@ func (c *HTTPClient) Send(data []byte) ([]byte, error) {
 	if !c.config.OriginalHost {
 		req.Host = c.config.url.Host
 	}
-
-	if c.config.url.Path == "" {
-		req.URL, _ = url.ParseRequestURI(c.config.url.Scheme + "://" + c.config.url.Host + req.RequestURI)
+	
+	// fix #862
+	if c.config.url.Path == "" && c.config.url.RawQuery == "" {
+		req.URL.Scheme = c.config.url.Scheme
+		req.URL.Host = c.config.url.Host
 	} else {
 		req.URL = c.config.url
 	}

--- a/output_http.go
+++ b/output_http.go
@@ -301,7 +301,12 @@ func (c *HTTPClient) Send(data []byte) ([]byte, error) {
 		req.Host = c.config.url.Host
 	}
 
-	req.URL, _ = url.ParseRequestURI(c.config.url.Scheme + "://" + c.config.url.Host + req.RequestURI)
+	if c.config.url.Path == "" {
+		req.URL, _ = url.ParseRequestURI(c.config.url.Scheme + "://" + c.config.url.Host + req.RequestURI)
+	} else {
+		req.URL = c.config.url
+	}
+	
 	// force connection to not be closed, which can affect the global client
 	req.Close = false
 	// it's an error if this is not equal to empty string

--- a/output_http.go
+++ b/output_http.go
@@ -301,7 +301,7 @@ func (c *HTTPClient) Send(data []byte) ([]byte, error) {
 		req.Host = c.config.url.Host
 	}
 
-	req.URL = c.config.url
+	req.URL, _ = url.ParseRequestURI(c.config.url.Scheme + "://" + c.config.url.Host + req.RequestURI)
 	// force connection to not be closed, which can affect the global client
 	req.Close = false
 	// it's an error if this is not equal to empty string


### PR DESCRIPTION
make the copy traffic url equal to original request url