### PR TITLE
Allow to display middleware stdout into goreplay stdout

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -41,6 +41,7 @@ func NewMiddleware(command string) *Middleware {
 	m.Stdin, _ = cmd.StdinPipe()
 
 	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
 
 	go m.read(m.Stdout)
 


### PR DESCRIPTION
Hi @buger,

First of all, thank you for maintaining this great tool!

I am writing a middleware in Go and I would like to be able to display some debug information in the stdout.
Without setting the command stdout to the operating system one, it did not printed anything. It looks like this does the trick.

Thank you