### PR TITLE
Close http.Response.Body to avoid http connection and goroutine leak.

### DIFF
--- a/output_http.go
+++ b/output_http.go
@@ -321,5 +321,6 @@ func (c *HTTPClient) Send(data []byte) ([]byte, error) {
 	if c.config.TrackResponses {
 		return httputil.DumpResponse(resp, true)
 	}
+	_ = resp.Body.Close()
 	return nil, nil
 }


### PR DESCRIPTION
fix #926 