### PR TITLE
input raw outbound flag

### DIFF
--- a/capture/capture.go
+++ b/capture/capture.go
@@ -285,13 +285,7 @@ func (l *Listener) SocketHandle(ifi net.Interface) (handle Socket, err error) {
 	if err = handle.SetPromiscuous(l.Promiscuous || l.Monitor); err != nil {
 		return nil, fmt.Errorf("promiscuous mode error: %q, interface: %q", err, ifi.Name)
 	}
-	if l.BPFFilter != "" {
-		if l.BPFFilter[0] != '(' || l.BPFFilter[len(l.BPFFilter)-1] != ')' {
-			l.BPFFilter = "(" + l.BPFFilter + ")"
-		}
-	} else {
-		l.BPFFilter = l.Filter(ifi)
-	}
+	l.BPFFilter = l.Filter(ifi)
 	fmt.Println("BPF Filter: ", l.BPFFilter)
 	if err = handle.SetBPFFilter(l.BPFFilter); err != nil {
 		handle.Close()
@@ -417,16 +411,12 @@ func (l *Listener) activatePcapFile() (err error) {
 	if handle, e = pcap.OpenOffline(l.host); e != nil {
 		return fmt.Errorf("open pcap file error: %q", e)
 	}
-	if l.BPFFilter != "" {
-		if l.BPFFilter[0] != '(' || l.BPFFilter[len(l.BPFFilter)-1] != ')' {
-			l.BPFFilter = "(" + l.BPFFilter + ")"
-		}
-	} else {
-		addr := l.host
-		l.host = ""
-		l.BPFFilter = l.Filter(net.Interface{})
-		l.host = addr
-	}
+
+	tmp := l.host
+	l.host = ""
+	l.BPFFilter = l.Filter(net.Interface{})
+	l.host = tmp
+
 	if e = handle.SetBPFFilter(l.BPFFilter); e != nil {
 		handle.Close()
 		return fmt.Errorf("BPF filter error: %q, filter: %s", e, l.BPFFilter)

--- a/capture/capture.go
+++ b/capture/capture.go
@@ -50,6 +50,7 @@ type Listener struct {
 	Engine        EngineType
 	port          uint16 // src or/and dst port
 	trackResponse bool
+	trackOutbound bool
 
 	host string // pcap file name or interface (name, hardware addr, index or ip address)
 
@@ -99,7 +100,7 @@ func (eng *EngineType) String() (e string) {
 // NewListener creates and initialize a new Listener. if transport or/and engine are invalid/unsupported
 // is "tcp" and "pcap", are assumed. l.Engine and l.Transport can help to get the values used.
 // if there is an error it will be associated with getting network interfaces
-func NewListener(host string, port uint16, transport string, engine EngineType, trackResponse bool) (l *Listener, err error) {
+func NewListener(host string, port uint16, transport string, engine EngineType, trackResponse bool, trackOutbound bool) (l *Listener, err error) {
 	l = &Listener{}
 
 	l.host = host
@@ -110,6 +111,7 @@ func NewListener(host string, port uint16, transport string, engine EngineType, 
 	}
 	l.Handles = make(map[string]gopacket.ZeroCopyPacketDataSource)
 	l.trackResponse = trackResponse
+	l.trackOutbound = trackOutbound
 	l.closeDone = make(chan struct{})
 	l.quit = make(chan struct{})
 	l.Reading = make(chan bool)

--- a/capture/capture.go
+++ b/capture/capture.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -170,21 +171,27 @@ func (l *Listener) ListenBackground(ctx context.Context, handler PacketHandler) 
 func (l *Listener) Filter(ifi net.Interface) (filter string) {
 	// https://www.tcpdump.org/manpages/pcap-filter.7.html
 
-	port := fmt.Sprintf("portrange 0-%d", 1<<16-1)
-	if l.port != 0 {
-		port = fmt.Sprintf("port %d", l.port)
-	}
-	filter = fmt.Sprintf("%s dst %s", l.Transport, port)
-	if l.trackResponse {
-		filter = fmt.Sprintf("%s %s", l.Transport, port)
-	}
+	filter = portsFilter(l.Transport, "dst", l.port)
 
+	hosts := []string{l.host}
 	if listenAll(l.host) || isDevice(l.host, ifi) {
-		return "(" + filter + ")"
+		hosts = interfaceAddresses(ifi)
 	}
-	filter = fmt.Sprintf("(host %s and (%s))", l.host, filter)
 
-	log.Println("BPF filter: " + filter)
+	if len(hosts) != 0 {
+		filter = fmt.Sprintf("((%s) and (%s))", filter, hostsFilter("dst", hosts))
+	}
+
+	if l.trackResponse {
+		responseFilter := portsFilter(l.Transport, "src", l.port)
+
+		if len(hosts) != 0 {
+			responseFilter = fmt.Sprintf("((%s) and (%s))", responseFilter, hostsFilter("src", hosts))
+		}
+
+		filter = fmt.Sprintf("%s or %s", filter, responseFilter)
+	}
+
 	return
 }
 
@@ -259,13 +266,7 @@ func (l *Listener) PcapHandle(ifi net.Interface) (handle *pcap.Handle, err error
 	if err != nil {
 		return nil, fmt.Errorf("PCAP Activate device error: %q, interface: %q", err, ifi.Name)
 	}
-	if l.BPFFilter != "" {
-		if l.BPFFilter[0] != '(' || l.BPFFilter[len(l.BPFFilter)-1] != ')' {
-			l.BPFFilter = "(" + l.BPFFilter + ")"
-		}
-	} else {
-		l.BPFFilter = l.Filter(ifi)
-	}
+	l.BPFFilter = l.Filter(ifi)
 	fmt.Println("Interface:", ifi.Name, ". BPF Filter:", l.BPFFilter)
 	err = handle.SetBPFFilter(l.BPFFilter)
 	if err != nil {
@@ -481,12 +482,40 @@ func isDevice(addr string, ifi net.Interface) bool {
 	return addr == ifi.Name || addr == fmt.Sprintf("%d", ifi.Index) || (addr != "" && addr == ifi.HardwareAddr.String())
 }
 
+func interfaceAddresses(ifi net.Interface) []string {
+	var hosts []string
+	if addrs, err := ifi.Addrs(); err == nil {
+		for _, addr := range addrs {
+			if ip := addr.(*net.IPNet).IP.String(); ip != "<nil>" {
+				hosts = append(hosts, ip)
+			}
+		}
+	}
+	return hosts
+}
+
 func listenAll(addr string) bool {
 	switch addr {
 	case "", "0.0.0.0", "[::]", "::":
 		return true
 	}
 	return false
+}
+
+func portsFilter(transport string, direction string, port uint16) string {
+	if port == 0 {
+		return fmt.Sprintf("%s %s portrange 0-%d", transport, direction, 1<<16-1)
+	}
+
+	return fmt.Sprintf("%s %s port %d", transport, direction, port)
+}
+
+func hostsFilter(direction string, hosts []string) string {
+	var hostsFilters []string
+	for _, host := range hosts {
+		hostsFilters = append(hostsFilters, fmt.Sprintf("%s host %s", direction, host))
+	}
+	return strings.Join(hostsFilters, " or ")
 }
 
 func pcapLinkTypeLength(lType int) (int, bool) {

--- a/capture/capture.go
+++ b/capture/capture.go
@@ -187,12 +187,16 @@ func (l *Listener) Filter(ifi net.Interface) (filter string) {
 
 		if len(hosts) != 0 {
 			filter = fmt.Sprintf("((%s) and (%s))", filter, hostsFilter("", hosts))
+		} else {
+			filter = fmt.Sprintf("(%s)", filter)
 		}
 	} else {
 		filter = portsFilter(l.Transport, "dst", l.port)
 
 		if len(hosts) != 0 {
 			filter = fmt.Sprintf("((%s) and (%s))", filter, hostsFilter("dst", hosts))
+		} else {
+			filter = fmt.Sprintf("(%s)", filter)
 		}
 
 		if l.trackResponse {
@@ -200,6 +204,8 @@ func (l *Listener) Filter(ifi net.Interface) (filter string) {
 
 			if len(hosts) != 0 {
 				responseFilter = fmt.Sprintf("((%s) and (%s))", responseFilter, hostsFilter("src", hosts))
+			} else {
+				responseFilter = fmt.Sprintf("(%s)", responseFilter)
 			}
 
 			filter = fmt.Sprintf("%s or %s", filter, responseFilter)

--- a/capture/capture_test.go
+++ b/capture/capture_test.go
@@ -84,7 +84,7 @@ func TestPcapDump(t *testing.T) {
 
 func testPcapDumpEngine(f string, t *testing.T) {
 	defer os.Remove(f)
-	l, err := NewListener(f, 8000, "", EnginePcapFile, true)
+	l, err := NewListener(f, 8000, "", EnginePcapFile, true, true)
 	err = l.Activate()
 	if err != nil {
 		t.Errorf("expected error to be nil, got %q", err)
@@ -109,7 +109,7 @@ func testPcapDumpEngine(f string, t *testing.T) {
 }
 
 func TestPcapHandler(t *testing.T) {
-	l, err := NewListener(LoopBack.Name, 8000, "", EnginePcap, true)
+	l, err := NewListener(LoopBack.Name, 8000, "", EnginePcap, true, true)
 	if err != nil {
 		t.Errorf("expected error to be nil, got %v", err)
 		return
@@ -186,7 +186,7 @@ func BenchmarkPcapFile(b *testing.B) {
 	f.Close()
 	b.ResetTimer()
 	var l *Listener
-	l, err = NewListener(name, 8000, "", EnginePcapFile, true)
+	l, err = NewListener(name, 8000, "", EnginePcapFile, true, true)
 	if err != nil {
 		b.Error(err)
 		return
@@ -232,7 +232,7 @@ func BenchmarkPcap(b *testing.B) {
 	var err error
 	n := new(int32)
 	counter := new(int32)
-	l, err := NewListener(LoopBack.Name, 8000, "", EnginePcap, false)
+	l, err := NewListener(LoopBack.Name, 8000, "", EnginePcap, false, true)
 	if err != nil {
 		b.Error(err)
 		return
@@ -274,7 +274,7 @@ func BenchmarkRawSocket(b *testing.B) {
 	var err error
 	n := new(int32)
 	counter := new(int32)
-	l, err := NewListener(LoopBack.Name, 8000, "", EngineRawSocket, false)
+	l, err := NewListener(LoopBack.Name, 8000, "", EngineRawSocket, false, true)
 	if err != nil {
 		b.Error(err)
 		return

--- a/capture/doc.go
+++ b/capture/doc.go
@@ -8,7 +8,7 @@ BPF filters can also be applied.
 example:
 
 // for the transport should be "tcp"
-listener, err := capture.NewListener(host, port, transport, engine, trackResponse)
+listener, err := capture.NewListener(host, port, transport, engine, trackResponse, trackOutbound)
 if err != nil {
 	// handle error
 }

--- a/input_raw.go
+++ b/input_raw.go
@@ -56,6 +56,7 @@ type RAWInputConfig struct {
 	CopyBufferSize size.Size          `json:"copy-buffer-size"`
 	Engine         capture.EngineType `json:"input-raw-engine"`
 	TrackResponse  bool               `json:"input-raw-track-response"`
+	TrackOutbound  bool               `json:"input-raw-track-outbound"`
 	Protocol       TCPProtocol        `json:"input-raw-protocol"`
 	RealIPHeader   string             `json:"input-raw-realip-header"`
 	Stats          bool               `json:"input-raw-stats"`
@@ -141,7 +142,7 @@ func (i *RAWInput) PluginRead() (*Message, error) {
 
 func (i *RAWInput) listen(address string) {
 	var err error
-	i.listener, err = capture.NewListener(i.host, i.port, "", i.Engine, i.TrackResponse)
+	i.listener, err = capture.NewListener(i.host, i.port, "", i.Engine, i.TrackResponse, i.TrackOutbound)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/input_raw_test.go
+++ b/input_raw_test.go
@@ -45,6 +45,7 @@ func TestRAWInputIPv4(t *testing.T) {
 		Expire:        0,
 		Protocol:      ProtocolHTTP,
 		TrackResponse: true,
+		TrackOutbound: true,
 		RealIPHeader:  "X-Real-IP",
 	}
 	input := NewRAWInput(listener.Addr().String(), conf)
@@ -110,6 +111,7 @@ func TestRAWInputNoKeepAlive(t *testing.T) {
 		Expire:        testRawExpire,
 		Protocol:      ProtocolHTTP,
 		TrackResponse: true,
+		TrackOutbound: true,
 	}
 	input := NewRAWInput(":"+port, conf)
 	var respCounter, reqCounter int64
@@ -175,6 +177,7 @@ func TestRAWInputIPv6(t *testing.T) {
 		Engine:        capture.EnginePcap,
 		Protocol:      ProtocolHTTP,
 		TrackResponse: true,
+		TrackOutbound: true,
 	}
 	input := NewRAWInput(originAddr, conf)
 
@@ -232,6 +235,7 @@ func TestInputRAWChunkedEncoding(t *testing.T) {
 		Expire:        time.Second,
 		Protocol:      ProtocolHTTP,
 		TrackResponse: true,
+		TrackOutbound: true,
 	}
 	input := NewRAWInput(originAddr, conf)
 
@@ -311,6 +315,7 @@ func BenchmarkRAWInputWithReplay(b *testing.B) {
 		Expire:        testRawExpire,
 		Protocol:      ProtocolHTTP,
 		TrackResponse: true,
+		TrackOutbound: true,
 	}
 	input := NewRAWInput(originAddr, conf)
 

--- a/settings.go
+++ b/settings.go
@@ -128,6 +128,7 @@ func init() {
 	// input raw flags
 	flag.Var(&Settings.InputRAW, "input-raw", "Capture traffic from given port (use RAW sockets and require *sudo* access):\n\t# Capture traffic from 8080 port\n\tgor --input-raw :8080 --output-http staging.com")
 	flag.BoolVar(&Settings.TrackResponse, "input-raw-track-response", false, "If turned on Gor will track responses in addition to requests, and they will be available to middleware and file output.")
+	flag.BoolVar(&Settings.TrackOutbound, "input-raw-track-outbound", false, "If turned on Gor will track outbound traffic.")
 	flag.Var(&Settings.Engine, "input-raw-engine", "Intercept traffic using `libpcap` (default), `raw_socket` or `pcap_file`")
 	flag.Var(&Settings.Protocol, "input-raw-protocol", "Specify application protocol of intercepted traffic. Possible values: http, binary")
 	flag.StringVar(&Settings.RealIPHeader, "input-raw-realip-header", "", "If not blank, injects header with given name and real IP value to the request payload. Usually this header should be named: X-Real-IP")


### PR DESCRIPTION
1. change bpf filter to capture only inbound traffic (default behavior)
2. added flag `input-raw-track-outbound` that will enable capture outbound traffic

given the argument `-input-raw 192.168.8.163:8080`, we can have 4 scenarios:
![image](https://user-images.githubusercontent.com/9161830/121159478-e4b77080-c853-11eb-9682-6b64dc39f027.png)

given the argument `-input-raw :8080` (without the host) - will resolve on listing all the nic IPv4 and IPv6 for example:
```
((tcp dst port 8000) and (host fe80::7d:ef91:7a11:c6ed or host 192.168.68.128 or ...))
```