### PR TITLE
Add windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.rpm
 *.dep
 *.pkg
+*.exe
 
 *.out
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ FPMCOMMON= \
     -s dir \
     -C /tmp/gor-build \
 
-release: release-x64 release-mac
+release: release-x64 release-mac release-windows
 
 release-bin:
 	docker run -v `pwd`:$(SOURCE_PATH) -t --env GOOS=linux --env GOARCH=amd64  -i $(CONTAINER) go build -o $(BIN_NAME) -tags netgo $(LDFLAGS)
@@ -58,11 +58,25 @@ release-mac:
 	fpm $(FPMCOMMON) -a amd64 -t osxpkg ./=/usr/local/bin
 	rm -rf /tmp/gor-build
 
+release-windows:
+	echo $(pwd)
+	docker run -it --rm \
+	  -v `pwd`:/go/src/github.com/buger/goreplay \
+	  -w /go/src/github.com/buger/goreplay \
+	  -e CGO_ENABLED=1 \
+	  docker.elastic.co/beats-dev/golang-crossbuild:1.16.4-main \
+	  --build-cmd "VERSION=make build" \
+	  -p "windows/amd64"
+
+	mv ./gor ./gor-$(VERSION)$(PREFIX).exe
+
+build:
+	go build -o $(BIN_NAME) $(LDFLAGS)
 
 install:
 	go install $(MAC_LDFLAGS)
 
-build:
+build-env:
 	docker build -t $(CONTAINER) -f Dockerfile.dev .
 
 profile:

--- a/capture/capture.go
+++ b/capture/capture.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"runtime"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/buger/goreplay/size"
@@ -18,7 +19,6 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
-	"golang.org/x/sys/unix"
 )
 
 // PacketHandler is a function that is used to handle packets
@@ -335,7 +335,7 @@ func (l *Listener) read(handler PacketHandler) {
 					if enext, ok := err.(pcap.NextError); ok && enext == pcap.NextErrorTimeoutExpired {
 						continue
 					}
-					if eno, ok := err.(unix.Errno); ok && eno.Temporary() {
+					if eno, ok := err.(syscall.Errno); ok && eno.Temporary() {
 						continue
 					}
 					if enet, ok := err.(*net.OpError); ok && (enet.Temporary() || enet.Timeout()) {


### PR DESCRIPTION
For a long time there were no official binaries for the windows platform.
One of the reasons is the complexities of the build toolchain. Not only CGO is required, but also installing the needed libraries and header files, not talking about mingw and etc.

2 weeks ago [golang-crossbuild](https://github.com/elastic/golang-crossbuild) project added native support for Libpcap based applications.
Windows support is based on the WinPcap which is a bit (a lot) outdated, BUT, since we depend only on its interface, it is still possible to use projects like npcap https://nmap.org/npcap/#download.

Npcap needs be installed with WinPcap compatibe mode (checkbox during installation)
It is also possibe install it in silent mode like this: `npcap-0.86.exe /S /winpcap_mode=yes`

After PR merge, will be updated related documentation.

Additionally fix dependency on "unix" package (apparently it can be totally replaced using universal syscall package)