### PR TITLE
Fix windows packet capture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,16 +59,16 @@ release-mac:
 	rm -rf /tmp/gor-build
 
 release-windows:
-	echo $(pwd)
 	docker run -it --rm \
 	  -v `pwd`:/go/src/github.com/buger/goreplay \
 	  -w /go/src/github.com/buger/goreplay \
 	  -e CGO_ENABLED=1 \
 	  docker.elastic.co/beats-dev/golang-crossbuild:1.16.4-main \
-	  --build-cmd "VERSION=make build" \
+	  --build-cmd "make VERSION=$(VERSION) build" \
 	  -p "windows/amd64"
-
-	mv ./gor ./gor-$(VERSION)$(PREFIX).exe
+	mv ./gor ./gor.exe
+	zip gor-$(VERSION)$(PREFIX)_windows.zip ./gor.exe
+	rm -rf ./gor.exe
 
 build:
 	go build -o $(BIN_NAME) $(LDFLAGS)

--- a/capture/sock_linux.go
+++ b/capture/sock_linux.go
@@ -44,7 +44,23 @@ type SockRaw struct {
 }
 
 // NewSocket returns new M'maped sock_raw on packet version 2.
-func NewSocket(ifi net.Interface) (*SockRaw, error) {
+func NewSocket(pifi pcap.Interface) (*SockRaw, error) {
+	var ifi net.Interface
+
+	infs, _ := net.Interfaces()
+	found := false
+	for _, i := range infs {
+		if i.Name == pifi.Name {
+			ifi = i
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return nil, fmt.Errorf("Can't find matching interface")
+	}
+
 	// sock create
 	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(ETHALL))
 	if err != nil {

--- a/capture/sock_others.go
+++ b/capture/sock_others.go
@@ -4,10 +4,11 @@ package capture
 
 import (
 	"errors"
-	"net"
+
+	"github.com/google/gopacket/pcap"
 )
 
 // NewSocket returns new M'maped sock_raw on packet version 2.
-func NewSocket(_ net.Interface) (Socket, error) {
+func NewSocket(_ pcap.Interface) (Socket, error) {
 	return nil, errors.New("afpacket socket is only available on linux")
 }

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -19,6 +19,7 @@ package proto
 import (
 	"bufio"
 	"bytes"
+	_ "fmt"
 	"net/http"
 	"net/textproto"
 	"strings"

--- a/tcp/tcp_message.go
+++ b/tcp/tcp_message.go
@@ -3,6 +3,7 @@ package tcp
 import (
 	"encoding/binary"
 	"encoding/hex"
+	_ "fmt"
 	"sort"
 	"time"
 
@@ -112,11 +113,7 @@ func (m *Message) MissingChunk() bool {
 }
 
 func (m *Message) PacketData() [][]byte {
-	var totalLen int
-	for _, p := range m.packets {
-		totalLen += len(p.Payload)
-	}
-	tmp := make([][]byte, totalLen)
+	tmp := make([][]byte, len(m.packets))
 
 	for i, p := range m.packets {
 		tmp[i] = p.Payload


### PR DESCRIPTION
Issues is that Go built-in net.Interfaces function in newer Windows versions return wrong interface names, which libpcap can't consume.
Now we use pcap.FindDevices instead of net.Interfaces.
See this Article for deep understanding of the issue https://haydz.github.io/2020/07/06/Go-Windows-NIC.html

Additionally, found a bug causing big memory allocations, for large requests, when we perform check if messages finished or not.
Because of this bug chunked body encoding check was not working properly.
Was not caught in tests, because test was working on packet array level, and this issue happens when dealing with TCP message object.

Additionally, added a small fix for windows Makefile task, it now generates proper file name.