### PR TITLE
removed zero copy

### DIFF
--- a/capture/af_packet.go
+++ b/capture/af_packet.go
@@ -21,8 +21,8 @@ func afpacketComputeSize(targetSizeMb int, snaplen int, pageSize int) (
 
 type afpacketHandle struct{}
 
-// ZeroCopyReadPacketData satisfies ZeroCopyPacketDataSource interface
-func (h *afpacketHandle) ZeroCopyReadPacketData() (data []byte, ci gopacket.CaptureInfo, err error) {
+// ReadPacketData satisfies PacketDataSource interface
+func (h *afpacketHandle) ReadPacketData() (data []byte, ci gopacket.CaptureInfo, err error) {
 	return nil, gopacket.CaptureInfo{}, fmt.Errorf("Not implemented")
 }
 

--- a/capture/af_packet_linux.go
+++ b/capture/af_packet_linux.go
@@ -60,9 +60,9 @@ func newAfpacketHandle(device string, snaplen int, block_size int, num_blocks in
 	return h, err
 }
 
-// ZeroCopyReadPacketData satisfies ZeroCopyPacketDataSource interface
-func (h *afpacketHandle) ZeroCopyReadPacketData() (data []byte, ci gopacket.CaptureInfo, err error) {
-	return h.TPacket.ZeroCopyReadPacketData()
+// ReadPacketData satisfies PacketDataSource interface
+func (h *afpacketHandle) ReadPacketData() (data []byte, ci gopacket.CaptureInfo, err error) {
+	return h.TPacket.ReadPacketData()
 }
 
 // SetBPFFilter translates a BPF filter string into BPF RawInstruction and applies them.

--- a/capture/capture.go
+++ b/capture/capture.go
@@ -58,7 +58,7 @@ type Listener struct {
 }
 
 type packetHandle struct {
-	handler gopacket.ZeroCopyPacketDataSource
+	handler gopacket.PacketDataSource
 	ips     []net.IP
 }
 
@@ -341,7 +341,7 @@ func (l *Listener) read(handler PacketHandler) {
 				case <-l.quit:
 					return
 				default:
-					data, ci, err := hndl.handler.ZeroCopyReadPacketData()
+					data, ci, err := hndl.handler.ReadPacketData()
 					if err == nil {
 						pckt, err := tcp.ParsePacket(data, linkType, linkSize, &ci, false)
 						if err == nil {

--- a/capture/sock_linux.go
+++ b/capture/sock_linux.go
@@ -126,7 +126,7 @@ func NewSocket(pifi pcap.Interface) (*SockRaw, error) {
 }
 
 // ReadPacketData implements gopacket.PacketDataSource.
-func (sock *SockRaw) ZeroCopyReadPacketData() (buf []byte, ci gopacket.CaptureInfo, err error) {
+func (sock *SockRaw) ReadPacketData() (buf []byte, ci gopacket.CaptureInfo, err error) {
 	sock.mu.Lock()
 	defer sock.mu.Unlock()
 	var tpHdr *unix.Tpacket2Hdr

--- a/capture/socket.go
+++ b/capture/socket.go
@@ -8,7 +8,7 @@ import (
 
 // Socket is any interface that defines the behaviors of Socket
 type Socket interface {
-	ZeroCopyReadPacketData() ([]byte, gopacket.CaptureInfo, error)
+	ReadPacketData() ([]byte, gopacket.CaptureInfo, error)
 	WritePacketData([]byte) error
 	SetBPFFilter(string) error
 	SetPromiscuous(bool) error


### PR DESCRIPTION
with and without the zero copy, the mem % was the same
but the cpu was worse when using the zero copy.

looks like the best approach will be to use PacketDataSource instead
--------------------------------------

added back go sync.Pool usage. as this pool evicts items from the pool, using 
```
pool chan *Packet
``` 
does not evicts items, does we get memory leak of buffers that are not evicted.
each buffer is allocated by `pckt.Payload = copySlice(pckt.Payload, ndata[dOf:])`
so sending a payload of `200K` will create a buffer of `200K`, multiply it by pool size `var packetPool = NewPool(10000)` 
we get `2G` pool size. sending `300K` will get us `3G`.


@buger