### PR TITLE
Fix file output size limit

### DIFF
--- a/output_file.go
+++ b/output_file.go
@@ -66,12 +66,12 @@ type FileOutput struct {
 	currentName    string
 	file           *os.File
 	QueueLength    int
-	chunkSize      int
 	writer         io.Writer
 	requestPerFile bool
 	currentID      []byte
 	payloadType    []byte
 	closed         bool
+	currentFileSize   int
 	totalFileSize  size.Size
 
 	config *FileOutputConfig
@@ -174,7 +174,7 @@ func (o *FileOutput) filename() string {
 
 		if o.currentName == "" ||
 			((o.config.QueueLimit > 0 && o.QueueLength >= o.config.QueueLimit) ||
-				(o.config.SizeLimit > 0 && o.chunkSize >= int(o.config.SizeLimit))) {
+				(o.config.SizeLimit > 0 && o.currentFileSize >= int(o.config.SizeLimit))) {
 			nextChunk = true
 		}
 
@@ -195,6 +195,7 @@ func (o *FileOutput) filename() string {
 
 				if nextChunk {
 					fileIndex++
+					o.currentFileSize = 0
 				}
 			}
 
@@ -253,6 +254,7 @@ func (o *FileOutput) PluginWrite(msg *Message) (n int, err error) {
 	n += nn
 
 	o.totalFileSize += size.Size(n)
+	o.currentFileSize += n
 	o.QueueLength++
 
 	if Settings.OutputFileConfig.OutputFileMaxSize > 0 && o.totalFileSize >= Settings.OutputFileConfig.OutputFileMaxSize {
@@ -281,7 +283,7 @@ func (o *FileOutput) flush() {
 		}
 
 		if stat, err := o.file.Stat(); err == nil {
-			o.chunkSize = int(stat.Size())
+			o.currentFileSize = int(stat.Size())
 		} else {
 			Debug(0, "[OUTPUT-HTTP] error accessing file size", err)
 		}

--- a/output_file.go
+++ b/output_file.go
@@ -62,17 +62,17 @@ type FileOutputConfig struct {
 // FileOutput output plugin
 type FileOutput struct {
 	sync.RWMutex
-	pathTemplate   string
-	currentName    string
-	file           *os.File
-	QueueLength    int
-	writer         io.Writer
-	requestPerFile bool
-	currentID      []byte
-	payloadType    []byte
-	closed         bool
-	currentFileSize   int
-	totalFileSize  size.Size
+	pathTemplate    string
+	currentName     string
+	file            *os.File
+	QueueLength     int
+	writer          io.Writer
+	requestPerFile  bool
+	currentID       []byte
+	payloadType     []byte
+	closed          bool
+	currentFileSize int
+	totalFileSize   size.Size
 
 	config *FileOutputConfig
 }


### PR DESCRIPTION
This should fix #973 . Tested with the following command:

```bash
gor --input-raw 127.0.0.1:8080 \
      --output-file '%Y-%m-%d.log' \
       --output-file-queue-limit 0 \
      --output-file-size-limit 1mb
```