### PR TITLE
Fix dupicated requests on linux

### DIFF
--- a/capture/capture.go
+++ b/capture/capture.go
@@ -598,12 +598,27 @@ func (l *Listener) setInterfaces() (err error) {
 			return
 		}
 
+		if runtime.GOOS != "windows" {
+			if len(pi.Addresses) == 0 {
+				continue
+			}
+
+			if ni.Flags&net.FlagUp == 0 {
+				continue
+			}
+		}
+
 		l.Interfaces = append(l.Interfaces, pi)
 	}
 	return
 }
 
 func isDevice(addr string, ifi pcap.Interface) bool {
+	// Windows npcap loopback have no IPs
+	if addr == "127.0.0.1" && ifi.Name == `\Device\NPF_Loopback` {
+		return true
+	}
+
 	if addr == ifi.Name {
 		return true
 	}


### PR DESCRIPTION
Issue was introduced while fixing windows https://github.com/buger/goreplay/commit/c9274ac92a6f021240d82682002240cfceaecd5e

Added exception for Windows, which by default allows interfaces without IPs.
Interface name check moved higher, so if interface namee or IP match, rest of check will be ignored.

Additionally windows npcap loopback mechanism can now be picked by specifying 127.0.0.1 or loopback IP.

Fix #989