### PR TITLE
capture-nics-fixups

### DIFF
--- a/capture/capture.go
+++ b/capture/capture.go
@@ -569,31 +569,31 @@ func (l *Listener) setInterfaces() (err error) {
 	}
 
 	for _, pi := range pifis {
+		if isDevice(l.host, pi) {
+			l.Interfaces = []pcap.Interface{pi}
+			return
+		}
+
 		var ni net.Interface
 		for _, i := range ifis {
+			if i.Name == pi.Name {
+				ni = i
+				break
+			}
+
 			addrs, _ := i.Addrs()
 			for _, a := range addrs {
 				for _, pa := range pi.Addresses {
-					if strings.HasPrefix(a.String(), pa.IP.String()) {
+					if a.String() == pa.IP.String() {
 						ni = i
 						break
 					}
 				}
 			}
-
-			if len(addrs) == 0 && i.Name == pi.Name {
-				ni = i
-				break
-			}
 		}
 
 		if ni.Flags&net.FlagLoopback != 0 {
 			l.loopIndex = ni.Index
-		}
-
-		if isDevice(l.host, pi) {
-			l.Interfaces = []pcap.Interface{pi}
-			return
 		}
 
 		if runtime.GOOS != "windows" {


### PR DESCRIPTION
1. move the `isDevice(l.host, pi)` to be first, as no need to iterate on all nics if it returns `true`
2. first compare by name, as same nics will have same names
3. if not found by name, compare by ips.

the bug was the `strings.HasPrefix`
2 different nics with ipv6:
```
#nic1 ip: f1234::55
#nic2 ip: f1234::55::66::66
```

so because of the `strings.HasPrefix` it was evaluated as the name nics. but they are not.


@buger  ^
it should also be a fix to `release-1.3`

