### PR TITLE
Missing messages fixes

### DIFF
--- a/capture/capture.go
+++ b/capture/capture.go
@@ -397,10 +397,12 @@ func (l *Listener) read() {
 					return
 				case <-timer.C:
 					if h, ok := hndl.handler.(PcapStatProvider); ok {
-						s, _ := h.Stats()
-						stats.Add("packets_received", int64(s.PacketsReceived))
-						stats.Add("packets_dropped", int64(s.PacketsDropped))
-						stats.Add("packets_if_dropped", int64(s.PacketsIfDropped))
+						s, err := h.Stats()
+						if err == nil {
+							stats.Add("packets_received", int64(s.PacketsReceived))
+							stats.Add("packets_dropped", int64(s.PacketsDropped))
+							stats.Add("packets_if_dropped", int64(s.PacketsIfDropped))
+						}
 					}
 				default:
 					data, ci, err := hndl.handler.ReadPacketData()
@@ -520,6 +522,9 @@ func (l *Listener) activatePcapFile() (err error) {
 		handle.Close()
 		return fmt.Errorf("BPF filter error: %q, filter: %s", e, l.BPFFilter)
 	}
+
+	fmt.Println("BPF Filter:", l.BPFFilter)
+
 	l.Handles["pcap_file"] = packetHandle{
 		handler: handle,
 	}

--- a/output_file.go
+++ b/output_file.go
@@ -195,7 +195,6 @@ func (o *FileOutput) filename() string {
 
 				if nextChunk {
 					fileIndex++
-					o.currentFileSize = 0
 				}
 			}
 
@@ -309,6 +308,8 @@ func (o *FileOutput) closeLocked() error {
 	}
 
 	o.closed = true
+	o.currentFileSize = 0
+
 	return nil
 }
 

--- a/proto/proto_test.go
+++ b/proto/proto_test.go
@@ -56,6 +56,12 @@ func TestHeader(t *testing.T) {
 	if val = Header(payload, []byte("host")); !bytes.Equal(val, []byte("www.w3.org")) {
 		t.Error("Should find lower case 1 word header")
 	}
+
+	payload = []byte("GT\r\nContent-Length: 10\r\n\r\n")
+
+	if val = Header(payload, []byte("Content-Length")); !bytes.Equal(val, []byte("10")) {
+		t.Error("Should find in partial payload")
+	}
 }
 
 func TestMIMEHeadersEndPos(t *testing.T) {

--- a/tcp/tcp_message.go
+++ b/tcp/tcp_message.go
@@ -353,34 +353,36 @@ func (parser *MessageParser) addPacket(m *Message, pckt *Packet) bool {
 	if parser.End != nil {
 		if parser.End(m) {
 			parser.Emit(m)
-		} else {
-			// Expect: 100-continue handling
-			if state, ok := m.feedback.(*proto.HTTPState); ok {
-				if state.Continue100 {
-					delete(parser.m, m.packets[0].MessageID())
-
-					// Shift Ack by given offset
-					// Size of "HTTP/1.1 100 Continue\r\n\r\n" message
-					for _, p := range m.packets {
-						p.messageID = 0
-						p.Ack += 25
-					}
-
-					// If next section was aready approved and received, merge messages
-					if next, found := parser.m[m.packets[0].MessageID()]; found {
-						for _, p := range next.packets {
-							parser.addPacket(m, p)
-						}
-					}
-
-					// Re-add (or override) again with new message and ID
-					parser.m[m.packets[0].MessageID()] = m
-				}
-			}
+			return true
 		}
+
+		parser.Fix100Continue(m)
 	}
 
 	return true
+}
+
+func (parser *MessageParser) Fix100Continue(m *Message) {
+	if state, ok := m.feedback.(*proto.HTTPState); ok && state.Continue100 {
+		delete(parser.m, m.packets[0].MessageID())
+
+		// Shift Ack by given offset
+		// Size of "HTTP/1.1 100 Continue\r\n\r\n" message
+		for _, p := range m.packets {
+			p.messageID = 0
+			p.Ack += 25
+		}
+
+		// If next section was aready approved and received, merge messages
+		if next, found := parser.m[m.packets[0].MessageID()]; found {
+			for _, p := range next.packets {
+				parser.addPacket(m, p)
+			}
+		}
+
+		// Re-add (or override) again with new message and ID
+		parser.m[m.packets[0].MessageID()] = m
+	}
 }
 
 func (parser *MessageParser) Read() *Message {

--- a/tcp/tcp_message.go
+++ b/tcp/tcp_message.go
@@ -168,6 +168,13 @@ func (m *Message) Data() []byte {
 		tmp, _ = copySlice(tmp, len(packetData[0]), packetData[1:]...)
 	}
 
+	// Remove Expect header, since its replay not fully supported
+	if state, ok := m.feedback.(*proto.HTTPState); ok {
+		if state.Continue100 {
+			tmp = proto.DeleteHeader(tmp, []byte("Expect"))
+		}
+	}
+
 	return tmp
 }
 
@@ -406,7 +413,6 @@ func (parser *MessageParser) timer(now time.Time) {
 			m.TimedOut = true
 			stats.Add("message_timeout_count", 1)
 			failMsg++
-
 			if parser.End == nil || parser.allowIncompete {
 				parser.Emit(m)
 			}

--- a/tcp/tcp_packet.go
+++ b/tcp/tcp_packet.go
@@ -169,7 +169,16 @@ func (pckt *Packet) parse(data []byte, lType, lTypeLen int, cp *gopacket.Capture
 		return ErrHdrLength("TCP opts")
 	}
 
-	if !allowEmpty && len(ndata[dOf:]) == 0 {
+	// There are case when packet have padding but dOf shows its not
+	empty := true
+	for i := 0; i < len(ndata[dOf:]); i++ {
+		if ndata[dOf:][i] != 0 {
+			empty = false
+			break
+		}
+	}
+
+	if !allowEmpty && empty {
 		return EmptyPacket("")
 	}
 

--- a/tcp/tcp_test.go
+++ b/tcp/tcp_test.go
@@ -217,7 +217,7 @@ func TestMessageTimeoutReached(t *testing.T) {
 	packets := GetPackets(true, 1, 2, data[:])
 	p := NewMessageParser(nil, nil, nil, 10*time.Millisecond, true)
 	p.processPacket(packets[0])
-	time.Sleep(time.Millisecond * 100)
+	time.Sleep(time.Millisecond * 200)
 	p.processPacket(packets[1])
 	m := p.Read()
 	if m.Length != 63<<10 {


### PR DESCRIPTION
This PR contains multiple fixes:
- Handle TCP padding (zeroes at the end of TCP payload), and do not treat it as a body
- Handle requests with "Expect: 100-Continue" - the ones which require confirmation from the server, before sending the body
- Fix muti-packet headers parsing, if "truncated" header starts with malformed header format
- Fix replay of pcap files (Ignore Stats method since it is not supported)
- Fix output file chunk size detection