### PR TITLE
VXLAN support for GoReplay

### DIFF
--- a/capture/vxlan.go
+++ b/capture/vxlan.go
@@ -1,0 +1,69 @@
+package capture
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"time"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+const VxLanPacketSize = 1526 //vxlan 8 B + ethernet II 1518 B
+
+type vxlanHandle struct {
+	connexion     *net.UDPConn
+	packetChannel chan gopacket.Packet
+}
+
+func newVXLANHandler() (*vxlanHandle, error) {
+	addr := net.UDPAddr{
+		Port: 4789,
+		IP:   net.ParseIP("0.0.0.0"),
+	}
+	vxlanHandle := &vxlanHandle{}
+	con, err := net.ListenUDP("udp", &addr)
+	if err != nil {
+		return nil, fmt.Errorf(err.Error())
+	}
+	vxlanHandle.connexion = con
+	vxlanHandle.packetChannel = make(chan gopacket.Packet, 1000)
+	go vxlanHandle.reader()
+
+	return vxlanHandle, nil
+}
+
+func (v *vxlanHandle) reader() {
+	for {
+		inputBytes := make([]byte, VxLanPacketSize)
+		length, _, err := v.connexion.ReadFromUDP(inputBytes)
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+			continue
+		}
+		packet := gopacket.NewPacket(inputBytes[:length], layers.LayerTypeVXLAN, gopacket.NoCopy)
+		ci := packet.Metadata()
+		ci.Timestamp = time.Now()
+		ci.CaptureLength = length
+		ci.Length = length
+		v.packetChannel <- packet
+	}
+}
+
+func (v *vxlanHandle) ReadPacketData() ([]byte, gopacket.CaptureInfo, error) {
+	packet := <-v.packetChannel
+	bytes := packet.Layer(layers.LayerTypeVXLAN).LayerPayload()
+
+	return bytes, packet.Metadata().CaptureInfo, nil
+}
+
+
+
+func (v *vxlanHandle) Close() error {
+	if v.connexion != nil {
+		return v.connexion.Close()
+	}
+	return nil
+}

--- a/docs/Capturing-and-replaying-traffic.md
+++ b/docs/Capturing-and-replaying-traffic.md
@@ -37,6 +37,11 @@ sudo gor --input-raw :80 --input-raw-engine "raw_socket" --output-http "http://s
 
 You can read more about [[Replaying HTTP traffic]].
 
+You can use VXLAN or traffic mirroring from AWS to capture the traffic. The 4789 UDP port will be opened and that works as you are launched GoReplay on the source machine.
+
+```
+gor --input-raw :80 --input-raw-engine vxlan -output-stdout
+```
 
 ### Tracking original IP addresses
 You can use `--input-raw-realip-header` option to specify header name: If not blank, injects header with given name and real IP value to the request payload. Usually, this header should be named: `X-Real-IP`, but you can specify any name.

--- a/tcp/tcp_message.go
+++ b/tcp/tcp_message.go
@@ -297,18 +297,28 @@ func (parser *MessageParser) parsePacket(pcapPkt *PcapPacket) *Packet {
 	}
 
 	for _, p := range parser.ports {
-		if pckt.DstPort == p {
-			for _, ip := range parser.ips {
-				if pckt.DstIP.Equal(ip) {
-					pckt.Direction = DirIncoming
-					break
-				}
-			}
+		if pckt.DstPort == p && containsOrEmpty(pckt.DstIP, parser.ips) {
+			pckt.Direction = DirIncoming
+			break
+		} else if pckt.SrcPort == p && containsOrEmpty(pckt.SrcIP, parser.ips) {
+			pckt.Direction = DirOutcoming
 			break
 		}
 	}
 
 	return pckt
+}
+
+func containsOrEmpty(element net.IP, ipList []net.IP) bool {
+	if len(ipList) == 0 {
+		return true
+	}
+	for _, ip := range ipList {
+		if ip.Equal(element) {
+			return true
+		}
+	}
+	return false
 }
 
 func (parser *MessageParser) processPacket(pckt *Packet) {


### PR DESCRIPTION
Go replay can record with pcap and call middleware for each exchange.
The middleware can analyze the traffic and make a report (debug, stats, and so on purpose).

This patch, provide the VXLAN support to capture the traffic. For example, if you are using AWS traffic mirroring, you can keep your middleware or forward to other goreplay.

The source ip source or port designed in '--input-raw' help to know the direction of the packet.

The 4789 UDP port is open and traffic is injected as with the pcap library.

```
./gor --input-raw :80 --input-raw-track-response --output-http-track-response --input-raw-engine vxlan --middleware my-favorite-middleware --output-null
```
```
./gor --input-raw :80 --input-raw-track-response --output-http-track-response --input-raw-engine vxlan -output-stdout
```

We have hard coded the port 4789 because: we haven't found satisfayeing method to add that in GoReplay arguments and it the default port of VXLAN. 
