### PR TITLE
feat(capture): add option to prevent any packet capture when no pods …

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -188,6 +188,7 @@ func init() {
 	flag.DurationVar(&Settings.InputRAWConfig.BufferTimeout, "input-raw-buffer-timeout", 0, "set the pcap timeout. for immediate mode don't set this flag")
 	flag.Var(&Settings.InputRAWConfig.BufferSize, "input-raw-buffer-size", "Controls size of the OS buffer which holds packets until they dispatched. Default value depends by system: in Linux around 2MB. If you see big package drop, increase this value.")
 	flag.BoolVar(&Settings.InputRAWConfig.Promiscuous, "input-raw-promisc", false, "enable promiscuous mode")
+	flag.BoolVar(&Settings.InputRAWConfig.K8sNoMatchPromisc, "input-raw-k8s-nomatch-promisc", false, "enable promiscuous mode when no matching pods are found in the cluster")
 	flag.BoolVar(&Settings.InputRAWConfig.Monitor, "input-raw-monitor", false, "enable RF monitor mode")
 	flag.BoolVar(&Settings.InputRAWConfig.Stats, "input-raw-stats", false, "enable stats generator on raw TCP messages")
 	flag.BoolVar(&Settings.InputRAWConfig.AllowIncomplete, "input-raw-allow-incomplete", false, "If turned on Gor will record HTTP messages with missing packets")


### PR DESCRIPTION
…match given k8s schema.

When there aren't any pods that match the given `k8s://` schema, the  BPF filter is updated to reflect the fact that there aren't any IPs/hosts to match, and instead it matches ports only. This could lead to capturing undesired packets from non-matching pods that use the same port. A boolean flag is introduced as an option to enabled/disable this behavior. It is disabled by default by updating the BPF filter to match no packets.