### PR TITLE
Fix buger/goreplay#1095

### DIFF
--- a/tcp/tcp_packet.go
+++ b/tcp/tcp_packet.go
@@ -17,8 +17,8 @@ func copySlice(to []byte, skip int, from ...[]byte) ([]byte, int) {
 	}
 	totalLen += skip
 
-	if cap(to) < totalLen {
-		diff := totalLen - cap(to)
+	if len(to) < totalLen {
+		diff := totalLen - len(to)
 		to = append(to, make([]byte, diff)...)
 	}
 

--- a/tcp/tcp_test.go
+++ b/tcp/tcp_test.go
@@ -216,10 +216,10 @@ func TestMessageTimeoutReached(t *testing.T) {
 	const size = 63 << 11
 	var data [size >> 1]byte
 	packets := GetPackets(true, 1, 2, data[:])
-	p := NewMessageParser(nil, nil, nil, 10*time.Millisecond, true)
+	p := NewMessageParser(nil, nil, nil, 100*time.Millisecond, true)
 	p.processPacket(packets[0])
 
-	time.Sleep(time.Second * 2)
+	time.Sleep(time.Millisecond * 20)
 
 	p.processPacket(packets[1])
 	m := p.Read()


### PR DESCRIPTION
The `copySlice` function inside `tcp_packet.go` wouldn't copy elements from the `from` slices to the `to` slice, even when the `to` slice has "space" to spare due to its `cap` being larger than the `totalLen`:

```go
func copySlice(to []byte, skip int, from ...[]byte) ([]byte, int) {
	var totalLen int
	for _, s := range from {
		totalLen += len(s)
	}
	totalLen += skip

	if cap(to) < totalLen {
		diff := totalLen - cap(to)
		to = append(to, make([]byte, diff)...)
	}

	for _, s := range from {
		skip += copy(to[skip:], s)
	}

	return to, skip
}
```

This is caused because Go's `copy` function used in `copySlice` will copy a number of elements ["which will be the minimum of len(src) and len(dst)."](https://pkg.go.dev/builtin#copy). For the built-in copy function to copy elements into a slice, the destination slots must be initialized for this slice, not just allocated in the underlying array. In other words, `len` must be used instead of `cap` to allow `copy` to work properly.

This PR closes #1095, which is an example of the effects of this issue: when mirroring packets using VXLAN, the raw payloads obtained using the vxlan engine can be large due to encapsulation. This has the effect of giving the `tmp` slice a large `cap` when `PacketData()` is called inside `tcp_message.go`. Then, the `to` slice is never resized in `copySlice` and only the first packet is read, without the rest (e.g. no response body, only headers are read).