### PR TITLE
Fix forwarding HTTP traffic to HTTPS endpoint in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM alpine:3.12 as builder
+FROM alpine:3.16 as builder
 
 ARG RELEASE_VERSION
 
 RUN apk add --no-cache ca-certificates openssl
-RUN wget https://github.com/buger/goreplay/releases/download/v${RELEASE_VERSION}/gor_${RELEASE_VERSION}_x64.tar.gz -O gor.tar.gz
+RUN wget https://github.com/buger/goreplay/releases/download/${RELEASE_VERSION}/gor_${RELEASE_VERSION}_x64.tar.gz -O gor.tar.gz
 RUN tar xzf gor.tar.gz
 
 FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /gor .
 ENTRYPOINT ["./gor"]


### PR DESCRIPTION
Scratch doesn't have root certificates by default, which means forwarding to a HTTPS endpoint doesn't work without skipping verification. To fix this, we can copy the certificate bundle into scratch from the alpine image.

I've also bumped the alpine version up to 3.16, and fixed the wget.

This has fixed my issues, but let me know if you think anything looks wrong here!