### PR TITLE
Fix ethernet trailers

### DIFF
--- a/capture/capture.go
+++ b/capture/capture.go
@@ -253,6 +253,7 @@ func (l *Listener) Listen(ctx context.Context) (err error) {
 							break
 						}
 					}
+
 					l.Unlock()
 				}
 			}
@@ -585,6 +586,10 @@ func (l *Listener) readHandle(key string, hndl packetHandle) {
 				continue
 			}
 			if err == io.EOF || err == io.ErrClosedPipe {
+				// File replays too fast, give it some time to process packets
+				if l.config.Engine == EnginePcapFile {
+					time.Sleep(time.Second)
+				}
 				log.Printf("stopped reading from %s interface with error %s\n", key, err)
 				return
 			}


### PR DESCRIPTION
When packet is less then 60 bytes, ethernet layer can add trailers to the end of packet, and current implementation treats it as packet with data.

IP layer has total length of the payload, so here we ensure that we limit TCP payload by the know length specified in IP header.
https://stackoverflow.com/questions/13738206/ip-packet-has-trailer-on-the-receiver-side-but-not-on-the-sender-side
	