### PR TITLE
Add info about --output-http-track-response to middleware docs

### DIFF
--- a/docs/Capturing-and-replaying-traffic.md
+++ b/docs/Capturing-and-replaying-traffic.md
@@ -26,6 +26,7 @@ gor --input-raw :80 --output-http "http://staging.com"  --output-http "http://de
 
 ### Tracking responses
 By default `input-raw` does not intercept responses, only requests. You can turn response tracking using `--input-raw-track-response` option. When enable you will be able to access response information in middleware and `output-file`.
+You need to set `--output-http-track-response` option if you want to track output responses in the middleware.
 
 
 ### Traffic interception engine

--- a/docs/Middleware.md
+++ b/docs/Middleware.md
@@ -59,8 +59,10 @@ Content-Type: text/plain; charset=utf-8
 
 ```
 
-Header contains request meta information separated by spaces. First value is payload type, possible values: `1` - request, `2` - original response, `3` - replayed response.
+Header contains request meta information separated by spaces. First value is payload type, possible values: `1` - request, `2` - original response, `3` - replayed response. 
 Next goes request id: unique among all requests (sha1 of time and Ack), but remain same for original and replayed response, so you can create associations between request and responses. The third argument is the time when request/response was initiated/received. Forth argument is populated only for responses and means latency.
+
+You need to set `--output-http-track-response` option if you want to track output responses in the middleware (payload type `3`).
 
 HTTP payload is unmodified HTTP requests/responses intercepted from network. You can read more about request format [here](http://www.jmarshall.com/easy/http/), [here](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol) and [here](http://www.w3.org/Protocols/rfc2616/rfc2616.html). You can operate with payload as you want, add headers, change path, and etc. Basically you just editing a string, just ensure that it is RCF compliant.
 


### PR DESCRIPTION
Add info to middleware related docs that `--output-http-track-response` is required to track output responses in the middleware.