### PR TITLE
Fix: Set current time instead of epoch 0(1970-01-01T00:00:00) in Kafka message metadata

### DIFF
--- a/output_kafka.go
+++ b/output_kafka.go
@@ -2,11 +2,12 @@ package goreplay
 
 import (
 	"encoding/json"
-	"github.com/buger/goreplay/internal/byteutils"
-	"github.com/buger/goreplay/proto"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/buger/goreplay/internal/byteutils"
+	"github.com/buger/goreplay/proto"
 
 	"github.com/Shopify/sarama"
 	"github.com/Shopify/sarama/mocks"
@@ -91,8 +92,9 @@ func (o *KafkaOutput) PluginWrite(msg *Message) (n int, err error) {
 	}
 
 	o.producer.Input() <- &sarama.ProducerMessage{
-		Topic: o.config.Topic,
-		Value: message,
+		Topic:     o.config.Topic,
+		Value:     message,
+		Timestamp: time.Now(),
 	}
 
 	return len(message), nil


### PR DESCRIPTION
Currently, `gor` sets epoch -1  in Kafka message metadata. Seems like issue with [Sarama](https://github.com/IBM/sarama) itself.

```
$ gdate -d @-1
Thu Jan  1 05:29:59 IST 1970

$ kcat -C -b "broker_1:9092, broker_2:9092" -t test.goreplay.service-x -o beginning -c 1 -f 'Topic %t [%p] at ts: %T offset %o: key %k: %s\n'
Topic test.goreplay.service-x [0] at ts: -1 offset 15785622: key :
```

After the fix:
```
$ kcat -C -b "broker-1:9092,broker-2:9092" -t test.goreplay.service-y -c 1 -o beginning -o beginning -c 1 -f 'Topic %t [%p] at ts: %T offset %o: key %k: %s\n'
Topictest.goreplay.service-y [0] at ts: 1735128339345 offset 0: key :
```